### PR TITLE
Refactor table block context and centralize filter logic

### DIFF
--- a/apps/blocks/blocks/table/filter_utils.py
+++ b/apps/blocks/blocks/table/filter_utils.py
@@ -1,0 +1,45 @@
+class FilterResolutionMixin:
+    """Common filter resolution helpers for table blocks and views."""
+
+    @staticmethod
+    def _resolve_filter_schema(raw_schema, user):
+        """Normalize raw filter schema and resolve callable choices."""
+        schema = {}
+        for key, cfg in raw_schema.items():
+            item = dict(cfg)
+            item.setdefault("type", "text")
+            if "choices" in item and callable(item["choices"]):
+                item["choices"] = item["choices"](user)
+            schema[key] = item
+        return schema
+
+    @staticmethod
+    def _collect_filters(qd, schema, base=None, *, prefix="filters.", allow_flat=True):
+        """Collect filter values from a QueryDict overlaying optional base values."""
+        base = dict(base or {})
+        if not schema:
+            return base
+
+        TRUTHY = {"1", "true", "on", "yes", "y", "t"}
+
+        for key, cfg in schema.items():
+            names = [f"{prefix}{key}"]
+            if allow_flat:
+                names.append(key)
+
+            for name in names:
+                if cfg.get("type") == "multiselect":
+                    vals = qd.getlist(name)
+                    if vals:
+                        base[key] = vals
+                        break
+                elif cfg.get("type") == "boolean":
+                    if name in qd:
+                        base[key] = (qd.get(name) or "").strip().lower() in TRUTHY
+                        break
+                else:
+                    raw = qd.get(name)
+                    if raw not in (None, ""):
+                        base[key] = raw
+                        break
+        return base

--- a/apps/blocks/blocks/table/table_block.py
+++ b/apps/blocks/blocks/table/table_block.py
@@ -2,13 +2,17 @@ from django.shortcuts import render
 from apps.blocks.models.block import Block
 from apps.blocks.models.block_column_config import BlockColumnConfig
 from apps.blocks.models.block_filter_config import BlockFilterConfig
-from apps.blocks.helpers.permissions import get_readable_fields_state, get_editable_fields_state
+from apps.blocks.helpers.permissions import (
+    get_readable_fields_state,
+    get_editable_fields_state,
+)
 from apps.blocks.helpers.field_rules import get_field_display_rules
 from django.db import models
 import json
-from apps.blocks.blocks.table.views import _resolve_filter_schema, _collect_filters
+from .filter_utils import FilterResolutionMixin
 
-class TableBlock:
+
+class TableBlock(FilterResolutionMixin):
     template_name = "blocks/table/table_block.html"
 
     def __init__(self, block_name):
@@ -40,146 +44,24 @@ class TableBlock:
         return BlockFilterConfig.objects.filter(user=user, block=self.block)
 
     def get_context(self, request):
-        model = self.get_model()
         user = request.user
-
-        column_config_id = request.GET.get("column_config_id")
-        filter_config_id = request.GET.get("filter_config_id")
-
-        column_configs = self.get_column_config_queryset(user)
-        filter_configs = self.get_filter_config_queryset(user)
-
-        active_column_config = None
-        if column_config_id:
-            try:
-                active_column_config = column_configs.get(pk=column_config_id)
-            except BlockColumnConfig.DoesNotExist:
-                pass
-        if not active_column_config:
-            active_column_config = column_configs.filter(is_default=True).first()
-
-        # --- filters: choose active saved filter (default if none in GET) ---
-        active_filter_config = None
-        if filter_config_id:
-            try:
-                active_filter_config = filter_configs.get(pk=filter_config_id)
-            except BlockFilterConfig.DoesNotExist:
-                pass
-        if not active_filter_config:
-            active_filter_config = filter_configs.filter(is_default=True).first()
-
-        # --- resolve schema (reuses your helper) ---
-        try:
-            raw_schema = self.get_filter_schema(request)  # if your block takes request
-        except TypeError:
-            raw_schema = self.get_filter_schema(user)  # backward-compat
-        filter_schema = _resolve_filter_schema(raw_schema, user)
-
-        # --- live (non-persistent) overrides from GET (no helper, inline for clarity) ---
-        base_values = active_filter_config.values if active_filter_config else {}
-
-        # merged values used to pre-populate fields and to filter queryset
-        selected_filter_values = _collect_filters(request.GET, filter_schema, base=base_values)
-        filter_values = selected_filter_values
-
-        selected_fields = active_column_config.fields if active_column_config else []
-
-        queryset = self.get_queryset(user, filter_values, active_column_config)
-        sample_obj = queryset.first() if queryset else None
-
-        # if not sample_obj:
-        #     return {
-        #         "block_name": self.block_name,
-        #         "fields": [],
-        #         "rows": [],
-        #         "tabulator_options": {},
-        #         "column_configs": column_configs,
-        #         "filter_configs": filter_configs,
-        #         "active_column_config_id": active_column_config.id if active_column_config else None,
-        #         "active_filter_config_id": active_filter_config.id if active_filter_config else None,
-        #     }
-
-        # Model introspection
-        model_list = []
-        model_list.append(model)
-        for field in model._meta.fields:
-            if isinstance(field, models.ForeignKey):
-                model_list.append(field.remote_field.model)
-
-
-        # Permissions
-        readable_fields = []
-        editable_fields = []
-        for m in model_list:
-            readable_fields.extend(get_readable_fields_state(user, m, sample_obj))
-            editable_fields.extend(get_editable_fields_state(user, m, sample_obj))
-
-        # Display Rules
-        model_label = f"{model._meta.app_label}.{model.__name__}"
-
-    #TODO: Later fix the issue where if a field is made mandatory/excluded, it should be reflected in final table. Since the configs wont be saved automaticallt until users saves it
-        # rules = get_field_display_rules(model_label)
-        # mandatory_fields = set(rules.get("mandatory", []))
-        # excluded_fields = set(rules.get("excluded", []))
-        # effective_fields = [f for f in selected_fields if f not in excluded_fields]
-        #
-        # for field in mandatory_fields:
-        #     if field not in effective_fields:
-        #         effective_fields.append(field)
-
-        display_rules = {
-            r.field_name: r for r in get_field_display_rules(model_label)
-        }
-
-        print("Display Rules:", display_rules)
-
-        # Final visible fields
-        visible_fields = [
-            f for f in selected_fields
-            if f in readable_fields and not (display_rules.get(f) and display_rules[f].is_excluded)
-        ]
-
-        # Column definitions
-        column_defs = {col["field"]: col["title"] for col in self.get_column_defs(user, active_column_config)}
-
-        fields = []
-        for f in visible_fields:
-            fields.append({
-                "name": f,
-                "label": column_defs.get(f, f.replace("_", " ").title()),
-                "mandatory": display_rules[f].is_mandatory if f in display_rules else False,
-                "editable": f in editable_fields,
-            })
-
-        # Construct data
-        data = []
-        for obj in queryset:
-            row = {}
-            for field in selected_fields:
-                if "__" in field:
-                    # Handle related fields
-                    related_field, sub_field = field.split("__", 1)
-                    related_obj = getattr(obj, related_field, None)
-                    value = getattr(related_obj, sub_field, None) if related_obj else None
-                else:
-                    # Handle regular fields
-                    value = getattr(obj, field, None)
-
-                # Replace None with an empty string and convert objects to strings
-                row[field] = value if value is not None else ""
-                if isinstance(value, (object, models.Model)):
-                    row[field] = str(value)
-
-            data.append(row)
-        from django.contrib.admin.utils import label_for_field
-        # Construct columns
-        columns = [
-            {
-                "title": label_for_field(field.get("field"), self.get_model(), return_attr=False),
-                "field": field.get("field"),
-            }
-            for field in self.get_column_defs(user, active_column_config)
-        ]
+        (
+            column_configs,
+            filter_configs,
+            active_column_config,
+            active_filter_config,
+            selected_fields,
+        ) = self._select_configs(request)
+        filter_schema, selected_filter_values = self._resolve_filters(
+            request, active_filter_config
+        )
+        queryset, sample_obj = self._build_queryset(
+            user, selected_filter_values, active_column_config
+        )
+        fields, columns = self._compute_fields(
+            user, selected_fields, active_column_config, sample_obj
+        )
+        data = self._serialize_rows(queryset, selected_fields)
         return {
             "block_name": self.block_name,
             "fields": fields,
@@ -189,10 +71,119 @@ class TableBlock:
             "active_column_config_id": active_column_config.id if active_column_config else None,
             "active_filter_config_id": active_filter_config.id if active_filter_config else None,
             "columns": columns,
-            "data": json.dumps(data),
-            "filter_schema": filter_schema,                       # ← added
-            "selected_filter_values": selected_filter_values,     # ← added
+            "data": data,
+            "filter_schema": filter_schema,
+            "selected_filter_values": selected_filter_values,
         }
+
+    def _select_configs(self, request):
+        user = request.user
+        column_config_id = request.GET.get("column_config_id")
+        filter_config_id = request.GET.get("filter_config_id")
+        column_configs = self.get_column_config_queryset(user)
+        filter_configs = self.get_filter_config_queryset(user)
+        active_column_config = None
+        if column_config_id:
+            try:
+                active_column_config = column_configs.get(pk=column_config_id)
+            except BlockColumnConfig.DoesNotExist:
+                pass
+        if not active_column_config:
+            active_column_config = column_configs.filter(is_default=True).first()
+        active_filter_config = None
+        if filter_config_id:
+            try:
+                active_filter_config = filter_configs.get(pk=filter_config_id)
+            except BlockFilterConfig.DoesNotExist:
+                pass
+        if not active_filter_config:
+            active_filter_config = filter_configs.filter(is_default=True).first()
+        selected_fields = active_column_config.fields if active_column_config else []
+        return (
+            column_configs,
+            filter_configs,
+            active_column_config,
+            active_filter_config,
+            selected_fields,
+        )
+
+    def _resolve_filters(self, request, active_filter_config):
+        user = request.user
+        try:
+            raw_schema = self.get_filter_schema(request)
+        except TypeError:
+            raw_schema = self.get_filter_schema(user)
+        filter_schema = self._resolve_filter_schema(raw_schema, user)
+        base_values = active_filter_config.values if active_filter_config else {}
+        selected_filter_values = self._collect_filters(
+            request.GET, filter_schema, base=base_values
+        )
+        return filter_schema, selected_filter_values
+
+    def _build_queryset(self, user, filter_values, active_column_config):
+        queryset = self.get_queryset(user, filter_values, active_column_config)
+        sample_obj = queryset.first() if queryset else None
+        return queryset, sample_obj
+
+    def _compute_fields(self, user, selected_fields, active_column_config, sample_obj):
+        model = self.get_model()
+        model_list = [model]
+        for field in model._meta.fields:
+            if isinstance(field, models.ForeignKey):
+                model_list.append(field.remote_field.model)
+        readable_fields = []
+        editable_fields = []
+        for m in model_list:
+            readable_fields.extend(get_readable_fields_state(user, m, sample_obj))
+            editable_fields.extend(get_editable_fields_state(user, m, sample_obj))
+        model_label = f"{model._meta.app_label}.{model.__name__}"
+        display_rules = {
+            r.field_name: r for r in get_field_display_rules(model_label)
+        }
+        visible_fields = [
+            f
+            for f in selected_fields
+            if f in readable_fields
+            and not (display_rules.get(f) and display_rules[f].is_excluded)
+        ]
+        column_defs = self.get_column_defs(user, active_column_config)
+        column_label_map = {col["field"]: col["title"] for col in column_defs}
+        fields = []
+        for f in visible_fields:
+            fields.append(
+                {
+                    "name": f,
+                    "label": column_label_map.get(f, f.replace("_", " ").title()),
+                    "mandatory": display_rules[f].is_mandatory if f in display_rules else False,
+                    "editable": f in editable_fields,
+                }
+            )
+        from django.contrib.admin.utils import label_for_field
+        columns = [
+            {
+                "title": label_for_field(defn.get("field"), self.get_model(), return_attr=False),
+                "field": defn.get("field"),
+            }
+            for defn in column_defs
+        ]
+        return fields, columns
+
+    def _serialize_rows(self, queryset, selected_fields):
+        data = []
+        for obj in queryset:
+            row = {}
+            for field in selected_fields:
+                if "__" in field:
+                    related_field, sub_field = field.split("__", 1)
+                    related_obj = getattr(obj, related_field, None)
+                    value = getattr(related_obj, sub_field, None) if related_obj else None
+                else:
+                    value = getattr(obj, field, None)
+                row[field] = value if value is not None else ""
+                if isinstance(value, (object, models.Model)):
+                    row[field] = str(value)
+            data.append(row)
+        return json.dumps(data)
 
     def render(self, request):
         return render(request, self.template_name, self.get_context(request))


### PR DESCRIPTION
## Summary
- extract reusable filter helpers into `FilterResolutionMixin`
- refactor `TableBlock.get_context` into orchestrated private methods
- update table views to use shared filter helpers

## Testing
- `python -m py_compile apps/blocks/blocks/table/filter_utils.py apps/blocks/blocks/table/views.py apps/blocks/blocks/table/table_block.py`
- `pytest -q`
- `python manage.py test` *(fails: Set the SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689a8305d8c88330995c169e5878a3e5