### PR TITLE
Refactor table block views to class-based forms

### DIFF
--- a/apps/blocks/blocks/table/views.py
+++ b/apps/blocks/blocks/table/views.py
@@ -1,92 +1,12 @@
-import json
-from django.http import JsonResponse, Http404
-from django.views.decorators.http import require_POST, csrf_exempt
+from django.http import Http404
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect, get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.contrib import messages
 
-from apps.workflow.permissions import can_write_field_state
 from apps.blocks.registry import block_registry
 from apps.blocks.models.block import Block
-from apps.blocks.models.block_column_config import BlockColumnConfig
 from apps.blocks.models.block_filter_config import BlockFilterConfig
-from apps.blocks.helpers.column_config import get_model_fields_for_column_config
-from .filter_utils import FilterResolutionMixin
 
-
-@csrf_exempt
-@require_POST
-@login_required
-def inline_edit(request, block_name):
-    try:
-        data = json.loads(request.body)
-        obj_id = data.get("id")
-        field = data.get("field")
-        value = data.get("value")
-
-        block = block_registry.get(block_name)
-        if not block:
-            return JsonResponse({"success": False, "error": "Invalid block"})
-
-        model = block.get_model()
-        instance = model.objects.get(id=obj_id)
-
-        if not can_write_field_state(request.user, model, field, instance):
-            return JsonResponse({"success": False, "error": "Permission denied"})
-
-        setattr(instance, field, value)
-        instance.save()
-
-        return JsonResponse({"success": True})
-
-    except Exception as e:
-        return JsonResponse({"success": False, "error": str(e)})
-
-
-@login_required
-def column_config_view(request, block_name):
-    block = Block.objects.get(name=block_name)
-    user = request.user
-    configs = BlockColumnConfig.objects.filter(block=block, user=user)
-
-    block_instance = block_registry.get(block_name)
-    if not block_instance:
-        raise Http404(f"Block '{block_name}' not found.")
-    model = block_instance.get_model()
-
-    fields_metadata = get_model_fields_for_column_config(model, user)
-
-    if request.method == "POST":
-        action = request.POST.get("action")
-        config_id = request.POST.get("config_id")
-        name = request.POST.get("name")
-
-        if action == "create":
-            fields = request.POST.get("fields", "")
-            field_list = [f.strip() for f in fields.split(",") if f.strip()]
-
-            existing = BlockColumnConfig.objects.filter(block=block, user=user, name=name).first()
-            if existing:
-                existing.fields = field_list
-                existing.save()
-            else:
-                BlockColumnConfig.objects.create(block=block, user=user, name=name, fields=field_list)
-
-        elif action == "delete":
-            BlockColumnConfig.objects.get(id=config_id, user=user, block=block).delete()
-
-        elif action == "set_default":
-            config = BlockColumnConfig.objects.get(id=config_id, user=user, block=block)
-            config.is_default = True
-            config.save()
-
-        return redirect("column_config_view", block_name=block_name)
-
-    return render(request, "blocks/table/column_config_view.html", {
-        "block": block,
-        "configs": configs,
-        "fields_metadata": fields_metadata,
-    })
 
 def render_table_block(request, block_name):
     block = block_registry.get(block_name)
@@ -95,75 +15,10 @@ def render_table_block(request, block_name):
     return block.render(request)
 
 
-
 def _get_db_block_or_404(block_name):
     # If your Block model uses slug instead of name, switch to slug=block_name
     return get_object_or_404(Block, name=block_name)
 
-@login_required
-def filter_config_view(request, block_name):
-    block_impl = block_registry.get(block_name)  # registry object (Python)
-    if not block_impl:
-        raise Http404("Invalid block")
-
-    db_block = _get_db_block_or_404(block_name)  # DB row
-
-    user_filters = BlockFilterConfig.objects.filter(
-        block=db_block, user=request.user
-    ).order_by("-is_default", "name")
-
-    editing = None
-    if request.method == "GET":
-        edit_id = request.GET.get("id")
-        if edit_id:
-            editing = get_object_or_404(
-                BlockFilterConfig, id=edit_id, block=db_block, user=request.user
-            )
-
-    raw_schema = block_impl.get_filter_schema(request)
-    filter_schema = FilterResolutionMixin._resolve_filter_schema(raw_schema, request.user)
-
-    if request.method == "POST":
-        edit_id = request.POST.get("id")
-        name = (request.POST.get("name") or "").strip()
-        is_default = bool(request.POST.get("is_default"))
-        if not name:
-            messages.error(request, "Please provide a name.")
-            return redirect("table_filter_config", block_name=block_name)
-
-        values = FilterResolutionMixin._collect_filters(request.POST, filter_schema, base={})
-
-        if edit_id:
-            cfg = get_object_or_404(
-                BlockFilterConfig, id=edit_id, block=db_block, user=request.user
-            )
-        else:
-            cfg = BlockFilterConfig(block=db_block, user=request.user)  # ← use DB block
-
-        cfg.name = name
-        cfg.values = values
-        cfg.is_default = is_default
-        cfg.save()
-        #
-        # if is_default:
-        #     BlockFilterConfig.objects.filter(
-        #         block=db_block, user=request.user
-        #     ).exclude(id=cfg.id).update(is_default=False)
-
-        messages.success(request, "Filter saved.")
-        return redirect(f"{request.path}?id={cfg.id}")
-
-    initial_values = editing.values if editing else {}
-    route_block_name = getattr(block_impl, "block_name", block_name)  # registry key you used in __init__
-
-    return render(request, "blocks/table/filter_config_view.html", {
-        "block": block_impl,
-        "route_block_name": route_block_name,
-        "user_filters": user_filters,
-        "editing": editing,
-        "filter_schema": filter_schema,
-        "initial_values": initial_values,
-    })
 
 @login_required
 def filter_delete_view(request, block_name, config_id):

--- a/apps/blocks/urls.py
+++ b/apps/blocks/urls.py
@@ -1,13 +1,16 @@
 from django.urls import path
 import apps.blocks.blocks.table.views as table_views
+from apps.blocks.views.inline_edit import InlineEditView
+from apps.blocks.views.column_config import ColumnConfigView
+from apps.blocks.views.filter_config import FilterConfigView
 
 urlpatterns = [
     path("table/<str:block_name>/", table_views.render_table_block, name="render_table_block"),
-    path("table/<str:block_name>/edit/", table_views.inline_edit, name="inline_edit"),
-    path("table/<str:block_name>/columns/", table_views.column_config_view, name="column_config_view"),
-path(
+    path("table/<str:block_name>/edit/", InlineEditView.as_view(), name="inline_edit"),
+    path("table/<str:block_name>/columns/", ColumnConfigView.as_view(), name="column_config_view"),
+    path(
         "table/<str:block_name>/filters/",
-        table_views.filter_config_view,
+        FilterConfigView.as_view(),
         name="table_filter_config",
     ),
     path(

--- a/apps/blocks/views/column_config.py
+++ b/apps/blocks/views/column_config.py
@@ -1,0 +1,69 @@
+from django import forms
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect
+from django.views.generic import FormView
+
+from apps.blocks.models.block import Block
+from apps.blocks.models.block_column_config import BlockColumnConfig
+from apps.blocks.helpers.column_config import get_model_fields_for_column_config
+from apps.blocks.registry import block_registry
+
+
+class ColumnConfigForm(forms.Form):
+    ACTIONS = (
+        ("create", "create"),
+        ("delete", "delete"),
+        ("set_default", "set_default"),
+    )
+    action = forms.ChoiceField(choices=ACTIONS)
+    config_id = forms.IntegerField(required=False)
+    name = forms.CharField(required=False)
+    fields = forms.CharField(required=False)
+
+
+class ColumnConfigView(LoginRequiredMixin, FormView):
+    template_name = "blocks/table/column_config_view.html"
+    form_class = ColumnConfigForm
+
+    def dispatch(self, request, block_name, *args, **kwargs):
+        self.block = get_object_or_404(Block, name=block_name)
+        self.block_instance = block_registry.get(block_name)
+        if not self.block_instance:
+            raise Http404(f"Block '{block_name}' not found.")
+        self.user = request.user
+        return super().dispatch(request, block_name, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        model = self.block_instance.get_model()
+        configs = BlockColumnConfig.objects.filter(block=self.block, user=self.user)
+        fields_metadata = get_model_fields_for_column_config(model, self.user)
+        context.update({
+            "block": self.block,
+            "configs": configs,
+            "fields_metadata": fields_metadata,
+        })
+        return context
+
+    def form_valid(self, form):
+        action = form.cleaned_data["action"]
+        config_id = form.cleaned_data.get("config_id")
+        name = form.cleaned_data.get("name")
+
+        if action == "create":
+            fields = form.cleaned_data.get("fields") or ""
+            field_list = [f.strip() for f in fields.split(",") if f.strip()]
+            existing = BlockColumnConfig.objects.filter(block=self.block, user=self.user, name=name).first()
+            if existing:
+                existing.fields = field_list
+                existing.save()
+            else:
+                BlockColumnConfig.objects.create(block=self.block, user=self.user, name=name, fields=field_list)
+        elif action == "delete" and config_id:
+            BlockColumnConfig.objects.get(id=config_id, user=self.user, block=self.block).delete()
+        elif action == "set_default" and config_id:
+            config = BlockColumnConfig.objects.get(id=config_id, user=self.user, block=self.block)
+            config.is_default = True
+            config.save()
+        return redirect("column_config_view", block_name=self.block.name)

--- a/apps/blocks/views/filter_config.py
+++ b/apps/blocks/views/filter_config.py
@@ -1,0 +1,102 @@
+from django import forms
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect
+from django.views.generic import FormView
+
+from apps.blocks.registry import block_registry
+from apps.blocks.models.block import Block
+from apps.blocks.models.block_filter_config import BlockFilterConfig
+from apps.blocks.blocks.table.filter_utils import FilterResolutionMixin
+
+
+class FilterConfigForm(forms.Form):
+    id = forms.IntegerField(required=False)
+    name = forms.CharField()
+    is_default = forms.BooleanField(required=False)
+
+    def __init__(self, *args, filter_schema=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filter_schema = filter_schema
+
+
+class FilterConfigView(LoginRequiredMixin, FilterResolutionMixin, FormView):
+    template_name = "blocks/table/filter_config_view.html"
+    form_class = FilterConfigForm
+
+    def dispatch(self, request, block_name, *args, **kwargs):
+        self.block_name = block_name
+        self.block_impl = block_registry.get(block_name)
+        if not self.block_impl:
+            raise Http404("Invalid block")
+        self.db_block = get_object_or_404(Block, name=block_name)
+        self.user_filters = BlockFilterConfig.objects.filter(
+            block=self.db_block, user=request.user
+        ).order_by("-is_default", "name")
+        self.editing = None
+        if request.method == "GET":
+            edit_id = request.GET.get("id")
+            if edit_id:
+                self.editing = get_object_or_404(
+                    BlockFilterConfig, id=edit_id, block=self.db_block, user=request.user
+                )
+        self.raw_schema = self.block_impl.get_filter_schema(request)
+        self.filter_schema = self._resolve_filter_schema(self.raw_schema, request.user)
+        return super().dispatch(request, block_name, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["filter_schema"] = self.filter_schema
+        return kwargs
+
+    def get_initial(self):
+        initial = super().get_initial()
+        if self.editing:
+            initial.update(
+                {
+                    "id": self.editing.id,
+                    "name": self.editing.name,
+                    "is_default": self.editing.is_default,
+                }
+            )
+        return initial
+
+    def form_valid(self, form):
+        edit_id = form.cleaned_data.get("id")
+        name = form.cleaned_data["name"].strip()
+        is_default = form.cleaned_data.get("is_default", False)
+        if not name:
+            messages.error(self.request, "Please provide a name.")
+            return redirect("table_filter_config", block_name=self.block_name)
+
+        values = self._collect_filters(self.request.POST, self.filter_schema, base={})
+
+        if edit_id:
+            cfg = get_object_or_404(
+                BlockFilterConfig, id=edit_id, block=self.db_block, user=self.request.user
+            )
+        else:
+            cfg = BlockFilterConfig(block=self.db_block, user=self.request.user)
+        cfg.name = name
+        cfg.values = values
+        cfg.is_default = is_default
+        cfg.save()
+        messages.success(self.request, "Filter saved.")
+        return redirect(f"{self.request.path}?id={cfg.id}")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        route_block_name = getattr(self.block_impl, "block_name", self.block_name)
+        initial_values = self.editing.values if self.editing else {}
+        context.update(
+            {
+                "block": self.block_impl,
+                "route_block_name": route_block_name,
+                "user_filters": self.user_filters,
+                "editing": self.editing,
+                "filter_schema": self.filter_schema,
+                "initial_values": initial_values,
+            }
+        )
+        return context


### PR DESCRIPTION
## Summary
- Add `InlineEditView` to handle table inline edits via a form-based POST API
- Introduce `ColumnConfigView` and `FilterConfigView` to validate configuration data using `FormView`
- Route block URLs to the new class-based views and trim unused function views

## Testing
- `SECRET_KEY=dev ALLOWED_HOSTS=localhost DATABASE_NAME=dev DATABASE_USER=dev DATABASE_PASS=dev DATABASE_HOST=localhost DATABASE_PORT=5432 EMAIL_HOST=localhost DEFAULT_FROM_EMAIL=test@example.com ADMINS=test@example.com python manage.py test` *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_689a85fd2e30833086fa5a4f4acbe792