### PR TITLE
refactor: centralize permissions and filtering

### DIFF
--- a/apps/blocks/blocks/table/table_block.py
+++ b/apps/blocks/blocks/table/table_block.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from apps.blocks.models.block import Block
 from apps.blocks.models.block_column_config import BlockColumnConfig
 from apps.blocks.models.block_filter_config import BlockFilterConfig
-from apps.blocks.helpers.permissions import (
+from apps.workflow.permissions import (
     get_readable_fields_state,
     get_editable_fields_state,
 )

--- a/apps/blocks/helpers/filter_config.py
+++ b/apps/blocks/helpers/filter_config.py
@@ -1,27 +1,10 @@
 from apps.blocks.models.block_filter_config import BlockFilterConfig
-from apps.blocks.registry import block_registry
 
 
 def get_user_filter_config(user, block):
+    """Return the default filter configuration for a user and block."""
     config = BlockFilterConfig.objects.filter(
         block=block, user=user, is_default=True
     ).first()
     return config.values if config else {}
-
-
-def apply_filter_registry(table_name, queryset, filters, user):
-    block = block_registry.get(table_name)
-
-    # Dynamic per-instance filter schema
-    if block and hasattr(block, "get_filter_schema"):
-        schema = block.get_filter_schema(user)
-    else:
-        schema = {}
-
-    print(schema)
-
-    for key, config in schema.items():
-        if key in filters and filters[key] is not None:
-            queryset = config["handler"](queryset, filters[key])
-    return queryset
 

--- a/apps/blocks/helpers/permissions.py
+++ b/apps/blocks/helpers/permissions.py
@@ -1,8 +1,0 @@
-from apps.workflow.permissions import get_readable_fields_state, get_editable_fields_state
-
-__all__ = ["get_readable_fields_state", "get_editable_fields_state"]
-
-
-## USAGE ##
-# from apps.blocks.helpers.permissions import get_readable_fields_state
-# fields = get_readable_fields_state(user, model, instance)

--- a/apps/blocks/services/__init__.py
+++ b/apps/blocks/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer for block related operations."""

--- a/apps/blocks/services/filtering.py
+++ b/apps/blocks/services/filtering.py
@@ -1,0 +1,35 @@
+"""Utilities for applying block filter registries."""
+
+import logging
+from apps.blocks.registry import block_registry
+
+logger = logging.getLogger(__name__)
+
+
+def apply_filter_registry(table_name, queryset, filters, user):
+    """Apply registered filter handlers to a queryset.
+
+    Args:
+        table_name (str): Name of the table block registered in ``block_registry``.
+        queryset (QuerySet): Initial queryset to filter.
+        filters (dict): Mapping of filter keys to values provided by the user.
+        user (User): Current user used for resolving dynamic filter schema.
+
+    Returns:
+        QuerySet: The queryset after all matching filters have been applied.
+    """
+    block = block_registry.get(table_name)
+
+    # Dynamic per-instance filter schema
+    if block and hasattr(block, "get_filter_schema"):
+        schema = block.get_filter_schema(user)
+    else:
+        schema = {}
+
+    logger.debug("Resolved filter schema for %s: %s", table_name, schema)
+
+    for key, config in schema.items():
+        if key in filters and filters[key] is not None:
+            logger.debug("Applying filter '%s' with value '%s'", key, filters[key])
+            queryset = config["handler"](queryset, filters[key])
+    return queryset

--- a/apps/production/blocks.py
+++ b/apps/production/blocks.py
@@ -1,6 +1,6 @@
 from apps.blocks.blocks.table.table_block import TableBlock
 from apps.common.models import ProductionOrder
-from apps.blocks.helpers.filter_config import apply_filter_registry
+from apps.blocks.services.filtering import apply_filter_registry
 
 class ProductionOrderTableBlock(TableBlock):
     def __init__(self):


### PR DESCRIPTION
## Summary
- delete blocks helper permissions shim
- move filter registry application into dedicated service with logging
- clean up helper modules by removing stray print statements

## Testing
- `python manage.py test` *(fails: Set the SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689a882256ec8330ac0fadeaa6832b62