### PR TITLE
refactor: share user config logic for block models

### DIFF
--- a/apps/blocks/models/base_user_config.py
+++ b/apps/blocks/models/base_user_config.py
@@ -1,0 +1,66 @@
+"""Common user configuration model for Blocks.
+
+This abstract model encapsulates fields and behaviour shared by user
+configuration models such as ``BlockColumnConfig`` and
+``BlockFilterConfig``.  The subclasses only need to declare their
+specific data payload (e.g. ``fields`` or ``values``).
+"""
+
+from django.db import models
+
+from apps.accounts.models.custom_user import CustomUser
+from apps.blocks.models.block import Block
+
+
+class BaseUserConfig(models.Model):
+    """Abstract base class for user-specific block configurations."""
+
+    block = models.ForeignKey(Block, on_delete=models.CASCADE)
+    user = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
+    name = models.CharField(max_length=255)
+    is_default = models.BooleanField(default=False)
+
+    class Meta:
+        abstract = True
+
+    # ------------------------------------------------------------------
+    # Common behaviour
+    # ------------------------------------------------------------------
+    def save(self, *args, **kwargs):  # noqa: D401 - behaviour documented in child
+        """Persist the configuration ensuring a single default per user.
+
+        When saving a new configuration and none exist for the user and block,
+        it becomes the default. If an existing configuration is marked as the
+        new default, all other configurations for the same user and block are
+        updated to not be default.
+        """
+
+        model = self.__class__
+
+        if not self.pk:
+            if not model.objects.filter(block=self.block, user=self.user).exists():
+                self.is_default = True
+        elif self.is_default:
+            model.objects.filter(block=self.block, user=self.user).exclude(pk=self.pk).update(
+                is_default=False
+            )
+
+        super().save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):  # noqa: D401 - behaviour documented in child
+        """Delete the configuration ensuring another default if required."""
+
+        model = self.__class__
+        configs = model.objects.filter(block=self.block, user=self.user)
+        if configs.count() <= 1:
+            raise Exception("At least one configuration must exist.")
+
+        was_default = self.is_default
+        super().delete(*args, **kwargs)
+
+        if was_default:
+            new_default = configs.exclude(pk=self.pk).order_by("pk").first()
+            if new_default:
+                new_default.is_default = True
+                new_default.save()
+

--- a/apps/blocks/models/block_column_config.py
+++ b/apps/blocks/models/block_column_config.py
@@ -1,39 +1,17 @@
-# apps/blocks/models/block_column_config.py
 from django.db import models
-from apps.accounts.models.custom_user import CustomUser
-from apps.blocks.models import Block
 
-class BlockColumnConfig(models.Model):
-    block = models.ForeignKey(Block, on_delete=models.CASCADE)
-    user = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
-    name = models.CharField(max_length=255)
+from apps.blocks.models.base_user_config import BaseUserConfig
+
+
+class BlockColumnConfig(BaseUserConfig):
+    """Stores column visibility configuration for a block and user."""
+
     fields = models.JSONField(default=list)
-    is_default = models.BooleanField(default=False)
 
     class Meta:
         constraints = [
             models.UniqueConstraint(
                 fields=["block", "user", "name"],
-                name="unique_column_config_per_user_block"
+                name="unique_column_config_per_user_block",
             )
         ]
-
-    def save(self, *args, **kwargs):
-        if not self.pk:
-            if not BlockColumnConfig.objects.filter(block=self.block, user=self.user).exists():
-                self.is_default = True
-        elif self.is_default:
-            BlockColumnConfig.objects.filter(block=self.block, user=self.user).exclude(pk=self.pk).update(is_default=False)
-        super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        configs = BlockColumnConfig.objects.filter(block=self.block, user=self.user)
-        if configs.count() <= 1:
-            raise Exception("At least one configuration must exist.")
-        was_default = self.is_default
-        super().delete(*args, **kwargs)
-        if was_default:
-            new_default = configs.exclude(pk=self.pk).order_by("pk").first()
-            if new_default:
-                new_default.is_default = True
-                new_default.save()

--- a/apps/blocks/models/block_filter_config.py
+++ b/apps/blocks/models/block_filter_config.py
@@ -1,30 +1,9 @@
 from django.db import models
-from apps.accounts.models.custom_user import CustomUser
-from apps.blocks.models.block import Block
 
-class BlockFilterConfig(models.Model):
-    block = models.ForeignKey(Block, on_delete=models.CASCADE)
-    user = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
-    name = models.CharField(max_length=255)
+from apps.blocks.models.base_user_config import BaseUserConfig
+
+
+class BlockFilterConfig(BaseUserConfig):
+    """Stores filter configuration for a block and user."""
+
     values = models.JSONField(default=dict)
-    is_default = models.BooleanField(default=False)
-
-    def save(self, *args, **kwargs):
-        if not self.pk:
-            if not BlockFilterConfig.objects.filter(block=self.block, user=self.user).exists():
-                self.is_default = True
-        elif self.is_default:
-            BlockFilterConfig.objects.filter(block=self.block, user=self.user).exclude(pk=self.pk).update(is_default=False)
-        super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        configs = BlockFilterConfig.objects.filter(block=self.block, user=self.user)
-        if configs.count() <= 1:
-            raise Exception("At least one filter configuration must exist.")
-        was_default = self.is_default
-        super().delete(*args, **kwargs)
-        if was_default:
-            new_default = configs.exclude(pk=self.pk).order_by("pk").first()
-            if new_default:
-                new_default.is_default = True
-                new_default.save()


### PR DESCRIPTION
## Summary
- add abstract BaseUserConfig with shared fields and save/delete behavior
- have BlockColumnConfig and BlockFilterConfig inherit the base

## Testing
- `python -m py_compile apps/blocks/models/base_user_config.py apps/blocks/models/block_column_config.py apps/blocks/models/block_filter_config.py`
- `SECRET_KEY=test ALLOWED_HOSTS=localhost DATABASE_NAME=test DATABASE_USER=postgres DATABASE_PASS=postgres DATABASE_HOST=localhost DATABASE_PORT=5432 EMAIL_HOST=localhost DEFAULT_FROM_EMAIL=test@example.com ADMINS=test@example.com python manage.py test apps.blocks` *(fails: ModuleNotFoundError: No module named 'dal')*
- `pip install django-autocomplete-light` *(fails: Could not find a version that satisfies the requirement django-autocomplete-light)*

------
https://chatgpt.com/codex/tasks/task_e_689a89e5e1988330b94c92209155095a