### PR TITLE
feat(blocks): introduce BaseBlock interface

### DIFF
--- a/apps/blocks/base.py
+++ b/apps/blocks/base.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+from django.shortcuts import render
+
+
+class BaseBlock(ABC):
+    """Base interface for block implementations.
+
+    Subclasses are expected to provide configuration data and the
+    runtime data separately via :meth:`get_config` and :meth:`get_data`.
+    The :meth:`render` method uses both pieces to render the block's
+    template.
+    """
+
+    template_name = ""
+    supported_features: list[str] = []
+
+    @abstractmethod
+    def get_config(self, request):
+        """Return configuration metadata for this block."""
+
+    @abstractmethod
+    def get_data(self, request):
+        """Return the data required to render this block."""
+
+    def render(self, request):
+        """Render the block using its template and context."""
+        config = self.get_config(request) or {}
+        data = self.get_data(request) or {}
+        context = {}
+        if isinstance(config, dict):
+            context.update(config)
+        if isinstance(data, dict):
+            context.update(data)
+        return render(request, self.template_name, context)

--- a/apps/blocks/registry.py
+++ b/apps/blocks/registry.py
@@ -1,37 +1,59 @@
 """Central registry for block implementations."""
 
+from .base import BaseBlock
+
 
 class BlockRegistry:
     """Store block implementations by identifier.
 
     The registry tracks registered blocks and prevents duplicate
     registrations.  Consumers can look up a block by its identifier or
-    iterate over all registered blocks.
+    iterate over all registered blocks.  Alongside each block instance the
+    registry keeps metadata such as supported features.
     """
 
     def __init__(self):
         self._blocks = {}
+        self._metadata = {}
 
     def register(self, block_id, block_instance):
         """Register ``block_instance`` under ``block_id``.
 
         Raises ``ValueError`` if ``block_id`` is already present in the
-        registry.
+        registry or ``TypeError`` if the instance is not a ``BaseBlock``
+        subclass.
         """
 
+        if not isinstance(block_instance, BaseBlock):
+            raise TypeError("block_instance must subclass BaseBlock")
         if block_id in self._blocks:
             raise ValueError(f"Block '{block_id}' is already registered")
         self._blocks[block_id] = block_instance
+        self._metadata[block_id] = {
+            "supported_features": getattr(block_instance, "supported_features", []),
+            "class": block_instance.__class__.__name__,
+        }
 
     def get(self, block_id):
         """Return the block registered under ``block_id`` if any."""
 
-        return self._blocks.get(block_id)
+        entry = self._blocks.get(block_id)
+        return entry
+
+    def metadata(self, block_id):
+        """Return metadata for ``block_id`` if present."""
+
+        return self._metadata.get(block_id, {})
 
     def all(self):
-        """Return a copy of the internal registry."""
+        """Return a copy of the internal registry mapping ids to instances."""
 
         return dict(self._blocks)
+
+    def all_metadata(self):
+        """Return metadata for all registered blocks."""
+
+        return dict(self._metadata)
 
 
 # Global registry instance used throughout the project.


### PR DESCRIPTION
## Summary
- add abstract `BaseBlock` providing common interface for blocks
- implement `get_config`/`get_data` in `TableBlock` and list supported features
- track block metadata in registry and enforce `BaseBlock` subclasses

## Testing
- `python -m py_compile apps/blocks/base.py apps/blocks/registry.py apps/blocks/blocks/table/table_block.py`
- `SECRET_KEY=test ALLOWED_HOSTS=localhost DATABASE_NAME=test DATABASE_USER=postgres DATABASE_PASS=postgres DATABASE_HOST=localhost DATABASE_PORT=5432 python manage.py test apps.blocks --keepdb` *(fails: Set the EMAIL_HOST environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689b69433b6483308c027f2524ad11c1