### PR TITLE
Add test for block registry loading

### DIFF
--- a/apps/blocks/apps.py
+++ b/apps/blocks/apps.py
@@ -1,4 +1,4 @@
-from importlib import import_module
+from importlib import import_module  # used for dynamic block loading
 
 from django.apps import AppConfig
 from django.conf import settings

--- a/apps/blocks/dummy_ready_callable.py
+++ b/apps/blocks/dummy_ready_callable.py
@@ -1,0 +1,15 @@
+from apps.blocks.base import BaseBlock
+
+
+class DummyCallableBlock(BaseBlock):
+    template_name = ""
+
+    def get_config(self, request):
+        return {}
+
+    def get_data(self, request):
+        return {}
+
+
+def register(registry):
+    registry.register("dummy_callable_block", DummyCallableBlock())

--- a/apps/blocks/dummy_ready_module.py
+++ b/apps/blocks/dummy_ready_module.py
@@ -1,0 +1,15 @@
+from apps.blocks.base import BaseBlock
+from apps.blocks.registry import block_registry
+
+
+class DummyModuleBlock(BaseBlock):
+    template_name = ""
+
+    def get_config(self, request):
+        return {}
+
+    def get_data(self, request):
+        return {}
+
+
+block_registry.register("dummy_module_block", DummyModuleBlock())

--- a/apps/blocks/test_appconfig.py
+++ b/apps/blocks/test_appconfig.py
@@ -1,0 +1,33 @@
+import sys
+from importlib import import_module
+from django.test import SimpleTestCase, override_settings
+
+from apps.blocks.apps import BlocksConfig
+from apps.blocks.registry import block_registry
+
+
+class BlocksConfigReadyTests(SimpleTestCase):
+    def setUp(self):
+        block_registry._blocks.clear()
+        block_registry._metadata.clear()
+        sys.modules.pop("apps.blocks.dummy_ready_module", None)
+        sys.modules.pop("apps.blocks.dummy_ready_callable", None)
+
+    def tearDown(self):
+        block_registry._blocks.clear()
+        block_registry._metadata.clear()
+        sys.modules.pop("apps.blocks.dummy_ready_module", None)
+        sys.modules.pop("apps.blocks.dummy_ready_callable", None)
+
+    def test_ready_loads_entries_from_settings(self):
+        entries = [
+            "apps.blocks.dummy_ready_module",
+            "apps.blocks.dummy_ready_callable:register",
+        ]
+        with override_settings(BLOCKS=entries):
+            config = BlocksConfig("apps.blocks", import_module("apps.blocks"))
+            config.ready()
+
+        all_blocks = block_registry.all()
+        assert "dummy_module_block" in all_blocks
+        assert "dummy_callable_block" in all_blocks

--- a/mag360/test_settings.py
+++ b/mag360/test_settings.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "test"
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = []
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+MIDDLEWARE = []
+ROOT_URLCONF = "mag360.test_urls"
+TEMPLATES = []
+USE_TZ = True
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/mag360/test_urls.py
+++ b/mag360/test_urls.py
@@ -1,0 +1,3 @@
+from django.urls import path
+
+urlpatterns = []


### PR DESCRIPTION
## Summary
- ensure `BlocksConfig.ready` imports block entrypoints using `import_module`
- test that entries listed in `settings.BLOCKS` are loaded into the registry

## Testing
- `DJANGO_SETTINGS_MODULE=mag360.test_settings python manage.py test apps.blocks.test_appconfig.BlocksConfigReadyTests -v 2`


------
https://chatgpt.com/codex/tasks/task_e_689b791757ac8330b4f0c450ecdad2da