### PR TITLE
Fix instance binding in PermissionFormMixin

### DIFF
--- a/apps/permissions/forms/__init__.py
+++ b/apps/permissions/forms/__init__.py
@@ -1,1 +1,4 @@
-from permission_form_mixin import PermissionFormMixin
+from .permission_form_mixin import PermissionFormMixin
+
+__all__ = ["PermissionFormMixin"]
+

--- a/apps/permissions/forms/permission_form_mixin.py
+++ b/apps/permissions/forms/permission_form_mixin.py
@@ -9,7 +9,7 @@ class PermissionFormMixin:
     """
 
     def __init__(self, *args, user=None, instance=None, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, instance=instance, **kwargs)
 
         if not user:
             raise ValueError("PermissionFormMixin requires a 'user' argument")

--- a/apps/permissions/tests.py
+++ b/apps/permissions/tests.py
@@ -1,3 +1,33 @@
+from django import forms
+from django.apps import apps as django_apps
+from django.db import models
 from django.test import TestCase
+from types import SimpleNamespace
 
-# Create your tests here.
+from apps.permissions.forms import PermissionFormMixin
+
+
+class DummyModel(models.Model):
+    name = models.CharField(max_length=100)
+
+    class Meta:
+        app_label = "permissions"
+
+
+django_apps.register_model("permissions", DummyModel)
+
+
+class DummyForm(PermissionFormMixin, forms.ModelForm):
+    class Meta:
+        model = DummyModel
+        fields = ["name"]
+
+
+class PermissionFormMixinTest(TestCase):
+    def test_instance_binding(self):
+        instance = DummyModel(name="foo")
+        user = SimpleNamespace(is_superuser=True, is_staff=True, has_perm=lambda perm: True)
+        form = DummyForm(user=user, instance=instance)
+
+        self.assertIs(form.instance, instance)
+        self.assertEqual(form.initial["name"], "foo")


### PR DESCRIPTION
## Summary
- forward `instance` to base class in `PermissionFormMixin.__init__`
- add regression test ensuring forms with `instance` bind correctly
- fix permissions forms package import

## Testing
- `python manage.py test apps.permissions.tests.PermissionFormMixinTest.test_instance_binding` *(fails: Set the ALLOWED_HOSTS environment variable)*
- `python - <<'PY' ...` (manual form binding check)


------
https://chatgpt.com/codex/tasks/task_e_689cf3031d008330baa209629c550f95