### PR TITLE
chore: remove unused imports in permission checks

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -1,7 +1,5 @@
 # apps/permissions/checks.py
 
-from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import QuerySet
 
 # --------------------


### PR DESCRIPTION
## Summary
- remove unused Permission and ContentType imports

## Testing
- `python -m py_compile apps/permissions/checks.py`
- `flake8 apps/permissions/checks.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf303e60c83309b24e0fd5aa9ca6c