### PR TITLE
Add instance support to permission template tags

### DIFF
--- a/apps/permissions/templatetags/permissions_tags.py
+++ b/apps/permissions/templatetags/permissions_tags.py
@@ -3,10 +3,23 @@ from apps.permissions.checks import can_read_field, can_write_field
 
 register = template.Library()
 
-@register.simple_tag
-def user_can_read(user, model, field_name):
-    return can_read_field(user, model, field_name)
 
 @register.simple_tag
-def user_can_write(user, model, field_name):
-    return can_write_field(user, model, field_name)
+def user_can_read(user, model, field_name, instance=None):
+    """Return whether ``user`` may read ``field_name`` on ``model``.
+
+    An optional ``instance`` can be supplied to include instance-level
+    permission checks.
+    """
+
+    return can_read_field(user, model, field_name, instance)
+
+
+@register.simple_tag
+def user_can_write(user, model, field_name, instance=None):
+    """Return whether ``user`` may edit ``field_name`` on ``model``.
+
+    When an ``instance`` is provided, instance-level permissions are honored.
+    """
+
+    return can_write_field(user, model, field_name, instance)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,19 @@
+# Permission Template Tags
+
+This project exposes template tags to perform field-level permission checks in Django templates.
+
+```django
+{% load permissions_tags %}
+
+{# Basic field check without an instance #}
+{% if user_can_read request.user MyModel 'status' %}
+    {{ object.status }}
+{% endif %}
+
+{# Instance-aware check #}
+{% if user_can_write request.user MyModel 'status' object %}
+    <!-- render editable field -->
+{% endif %}
+```
+
+Both `user_can_read` and `user_can_write` accept an optional `instance` argument to apply instance-level permission logic.


### PR DESCRIPTION
## Summary
- allow `user_can_read` and `user_can_write` template tags to accept an optional instance
- document instance-aware usage of permission tags

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dal')*


------
https://chatgpt.com/codex/tasks/task_e_689cf307dd608330a3d1a1ae65e82907