### PR TITLE
refactor: use specific model permission helpers

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -37,7 +37,7 @@ def can_view_instance(user, instance):
     model = type(instance)
     if user.is_superuser or user.is_staff:
         return True
-    if not can_act_on_model(user, model, "view"):
+    if not can_view_model(user, model):
         return False
     if hasattr(instance, "can_user_view"):
         return instance.can_user_view(user)
@@ -47,7 +47,7 @@ def can_change_instance(user, instance):
     model = type(instance)
     if user.is_superuser or user.is_staff:
         return True
-    if not can_act_on_model(user, model, "change"):
+    if not can_change_model(user, model):
         return False
     if hasattr(instance, "can_user_change"):
         return instance.can_user_change(user)
@@ -57,7 +57,7 @@ def can_delete_instance(user, instance):
     model = type(instance)
     if user.is_superuser or user.is_staff:
         return True
-    if not can_act_on_model(user, model, "delete"):
+    if not can_delete_model(user, model):
         return False
     if hasattr(instance, "can_user_delete"):
         return instance.can_user_delete(user)
@@ -75,7 +75,7 @@ def _get_perm_codename(model, field_name, action):
 def can_read_field(user, model, field_name, instance=None):
     if user.is_superuser or user.is_staff:
         return True
-    if not can_act_on_model(user, model, "view"):
+    if not can_view_model(user, model):
         return False
     if instance and not can_view_instance(user, instance):
         return False
@@ -84,7 +84,7 @@ def can_read_field(user, model, field_name, instance=None):
 def can_write_field(user, model, field_name, instance=None):
     if user.is_superuser or user.is_staff:
         return True
-    if not can_act_on_model(user, model, "change"):
+    if not can_change_model(user, model):
         return False
     if instance and not can_change_instance(user, instance):
         return False


### PR DESCRIPTION
## Summary
- use dedicated model permission helpers when checking instance and field access

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d1aeb63848330814400819b13f34f