### PR TITLE
Skip permission generation for auto-created or read-only fields

### DIFF
--- a/apps/permissions/signals/generate_field_permissions.py
+++ b/apps/permissions/signals/generate_field_permissions.py
@@ -8,7 +8,8 @@ from django.contrib.contenttypes.models import ContentType
 def generate_field_permissions(sender, **kwargs):
     """
     After every migrate, ensure each concrete model field has a
-    view_ and change_ permission (i.e. read/write) in Django's auth system.
+    view_ and change_ permission (i.e. read/write) in Django's auth system,
+    excluding auto-created and non-editable fields.
     """
     for model in django_apps.get_models():
         ct = ContentType.objects.get_for_model(model)
@@ -16,6 +17,8 @@ def generate_field_permissions(sender, **kwargs):
         verbose_name = model._meta.verbose_name.title()
 
         for field in model._meta.fields:
+            if field.auto_created or not field.editable:
+                continue  # Skip auto-created or read-only fields
             field_name = field.name
 
             # READ permission


### PR DESCRIPTION
## Summary
- avoid generating permissions for auto-created or non-editable fields
- clarify docstring for field permission generation

## Testing
- `python -m py_compile apps/permissions/signals/generate_field_permissions.py`
- `SECRET_KEY=dummy ALLOWED_HOSTS='*' python manage.py test` *(fails: `django.core.exceptions.ImproperlyConfigured: Set the DATABASE_NAME environment variable`)*

------
https://chatgpt.com/codex/tasks/task_e_689d1f5a09348330af7b2b947c5fb7e5