### PR TITLE
Include M2M fields in permission checks

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -91,16 +91,23 @@ def can_write_field(user, model, field_name, instance=None):
     return user.has_perm(_get_perm_codename(model, field_name, "change"))
 
 def get_readable_fields(user, model, instance=None):
+    """Return names of model fields the user may read, including M2M fields."""
+
+    fields = list(model._meta.fields) + list(model._meta.many_to_many)
     return [
         field.name
-        for field in model._meta.fields
+        for field in fields
         if can_read_field(user, model, field.name, instance)
     ]
 
+
 def get_editable_fields(user, model, instance=None):
+    """Return names of model fields the user may edit, including M2M fields."""
+
+    fields = list(model._meta.fields) + list(model._meta.many_to_many)
     return [
         field.name
-        for field in model._meta.fields
+        for field in fields
         if can_write_field(user, model, field.name, instance)
     ]
 

--- a/apps/permissions/signals/generate_field_permissions.py
+++ b/apps/permissions/signals/generate_field_permissions.py
@@ -16,7 +16,12 @@ def generate_field_permissions(sender, **kwargs):
         model_name = model._meta.model_name
         verbose_name = model._meta.verbose_name.title()
 
-        for field in model._meta.fields:
+        # Iterate over concrete fields and explicit many-to-many relations.
+        # ``model._meta.many_to_many`` captures user-defined M2M fields
+        # (excluding auto-created reverse relations). Including these ensures
+        # we create field-level permissions for them just like any standard
+        # field.
+        for field in list(model._meta.fields) + list(model._meta.many_to_many):
             if field.auto_created or not field.editable:
                 continue  # Skip auto-created or read-only fields
             field_name = field.name

--- a/apps/permissions/tests.py
+++ b/apps/permissions/tests.py
@@ -1,5 +1,66 @@
 from django import forms
-from django.apps import apps as django_apps
-from django.db import models
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from types import SimpleNamespace
+
+from apps.permissions.checks import get_editable_fields, get_readable_fields
+from apps.permissions.forms import PermissionFormMixin
+from apps.permissions.signals.generate_field_permissions import (
+    generate_field_permissions,
+)
+
+
+User = get_user_model()
+
+
+class UserForm(PermissionFormMixin, forms.ModelForm):
+    class Meta:
+        model = User
+        fields = ["username", "groups"]
+
+
+class M2MPermissionsTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Ensure permissions exist for User model fields, including M2M ones
+        generate_field_permissions(None)
+
+    def test_generate_permissions_for_m2m_field(self):
+        ct = ContentType.objects.get_for_model(User)
+        self.assertTrue(
+            Permission.objects.filter(
+                content_type=ct, codename="view_user_groups"
+            ).exists()
+        )
+        self.assertTrue(
+            Permission.objects.filter(
+                content_type=ct, codename="change_user_groups"
+            ).exists()
+        )
+
+    def test_get_fields_includes_m2m(self):
+        user = SimpleNamespace(is_superuser=True, is_staff=False, has_perm=lambda p: True)
+        self.assertIn("groups", get_readable_fields(user, User))
+        self.assertIn("groups", get_editable_fields(user, User))
+
+    def test_permission_form_mixin_handles_m2m(self):
+        # User without permissions shouldn't see the field
+        user_none = SimpleNamespace(is_superuser=False, is_staff=False, has_perm=lambda p: False)
+        form = UserForm(user=user_none)
+        self.assertNotIn("groups", form.fields)
+
+        # User with read but not write permission sees disabled field
+        def has_perm(perm):
+            return perm in {
+                "auth.view_user",
+                "auth.change_user",
+                "auth.view_user_groups",
+            }
+
+        user_read_only = SimpleNamespace(is_superuser=False, is_staff=False, has_perm=has_perm)
+        form = UserForm(user=user_read_only)
+        self.assertIn("groups", form.fields)
+        self.assertTrue(form.fields["groups"].disabled)
+


### PR DESCRIPTION
## Summary
- generate field-level permissions for M2M fields
- include many-to-many relations in readable/editable field helpers
- align PermissionFormMixin with new permission helpers and add tests for M2M handling

## Testing
- `SECRET_KEY=dummy ALLOWED_HOSTS=localhost DATABASE_NAME=test DATABASE_USER=postgres DATABASE_PASS=postgres DATABASE_HOST=localhost DATABASE_PORT=5432 python manage.py test apps.permissions` *(fails: Set the EMAIL_HOST environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689d2923b9b48330957ccc022788c888