### PR TITLE
Add permission template tags for models and instances

### DIFF
--- a/apps/permissions/templatetags/permissions_tags.py
+++ b/apps/permissions/templatetags/permissions_tags.py
@@ -1,5 +1,15 @@
 from django import template
-from apps.permissions.checks import can_read_field, can_write_field
+from apps.permissions.checks import (
+    can_add_model,
+    can_change_instance,
+    can_change_model,
+    can_delete_instance,
+    can_delete_model,
+    can_read_field,
+    can_view_instance,
+    can_view_model,
+    can_write_field,
+)
 
 register = template.Library()
 
@@ -23,3 +33,52 @@ def user_can_write(user, model, field_name, instance=None):
     """
 
     return can_write_field(user, model, field_name, instance)
+
+
+@register.simple_tag
+def user_can_view_model(user, model):
+    """Return whether ``user`` may view ``model``."""
+
+    return can_view_model(user, model)
+
+
+@register.simple_tag
+def user_can_add_model(user, model):
+    """Return whether ``user`` may add ``model`` instances."""
+
+    return can_add_model(user, model)
+
+
+@register.simple_tag
+def user_can_change_model(user, model):
+    """Return whether ``user`` may change ``model`` instances."""
+
+    return can_change_model(user, model)
+
+
+@register.simple_tag
+def user_can_delete_model(user, model):
+    """Return whether ``user`` may delete ``model`` instances."""
+
+    return can_delete_model(user, model)
+
+
+@register.simple_tag
+def user_can_view_instance(user, instance):
+    """Return whether ``user`` may view ``instance``."""
+
+    return can_view_instance(user, instance)
+
+
+@register.simple_tag
+def user_can_change_instance(user, instance):
+    """Return whether ``user`` may change ``instance``."""
+
+    return can_change_instance(user, instance)
+
+
+@register.simple_tag
+def user_can_delete_instance(user, instance):
+    """Return whether ``user`` may delete ``instance``."""
+
+    return can_delete_instance(user, instance)

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,19 +1,34 @@
 # Permission Template Tags
 
-This project exposes template tags to perform field-level permission checks in Django templates.
+This project exposes template tags that mirror the utilities in
+`apps.permissions.checks`. They allow model-, instance-, and field-level
+permission checks directly in Django templates so you can conditionally render
+UI elements.
 
 ```django
 {% load permissions_tags %}
 
-{# Basic field check without an instance #}
+{# Model-level check #}
+{% if user_can_add_model request.user MyModel %}
+    <a href="{% url 'mymodel_add' %}">Add Model</a>
+{% endif %}
+
+{# Instance-level check #}
+{% if user_can_change_instance request.user object %}
+    <a href="{% url 'mymodel_edit' object.pk %}">Edit</a>
+{% endif %}
+
+{# Field-level check without an instance #}
 {% if user_can_read request.user MyModel 'status' %}
     {{ object.status }}
 {% endif %}
 
-{# Instance-aware check #}
+{# Field-level check honoring instance-level permissions #}
 {% if user_can_write request.user MyModel 'status' object %}
     <!-- render editable field -->
 {% endif %}
 ```
 
-Both `user_can_read` and `user_can_write` accept an optional `instance` argument to apply instance-level permission logic.
+All of these tags delegate to similarly named functions in
+`apps.permissions.checks` and return booleans indicating whether the `user` has
+the requisite permission.


### PR DESCRIPTION
## Summary
- Expose template tags for model- and instance-level permission checks
- Document how to conditionally render template UI using permission tags

## Testing
- `SECRET_KEY='dummy' ALLOWED_HOSTS='*' DATABASE_NAME='db' DATABASE_USER='user' DATABASE_PASS='pass' DATABASE_HOST='localhost' DATABASE_PORT='5432' python manage.py test` *(fails: Set the EMAIL_HOST environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689d2924f9cc83308aa93105ab3f729b