### PR TITLE
Clear permission cache between requests

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -20,7 +20,7 @@ from django.db.models import QuerySet
 # per-request user.has_perm caching
 # ---------------------------------
 
-_perm_cache_var: ContextVar[dict] = ContextVar("perm_cache", default={})
+_perm_cache_var: ContextVar[dict | None] = ContextVar("perm_cache", default=None)
 _cache_disabled_var: ContextVar[bool] = ContextVar("perm_cache_disabled", default=False)
 
 
@@ -31,6 +31,9 @@ def _cached_has_perm(user, perm: str) -> bool:
         return user.has_perm(perm)
 
     cache = _perm_cache_var.get()
+    if cache is None:
+        cache = {}
+        _perm_cache_var.set(cache)
     key = (id(user), perm)
     if key not in cache:
         cache[key] = user.has_perm(perm)
@@ -44,7 +47,7 @@ def clear_perm_cache() -> None:
     ensure fresh permission checks and prevent unbounded cache growth.
     """
 
-    _perm_cache_var.set({})
+    _perm_cache_var.set(None)
 
 
 @contextmanager

--- a/apps/permissions/middleware.py
+++ b/apps/permissions/middleware.py
@@ -1,0 +1,27 @@
+from asgiref.sync import iscoroutinefunction
+
+from .checks import clear_perm_cache
+
+
+class PermissionCacheMiddleware:
+    """Clear the permission cache after each request."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self._is_async = iscoroutinefunction(get_response)
+
+    def __call__(self, request):
+        if self._is_async:
+            return self._acall(request)
+        try:
+            response = self.get_response(request)
+        finally:
+            clear_perm_cache()
+        return response
+
+    async def _acall(self, request):
+        try:
+            response = await self.get_response(request)
+        finally:
+            clear_perm_cache()
+        return response

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,4 +1,19 @@
-# Permission Template Tags
+# Permissions
+
+## Cache-clearing middleware
+
+`apps.permissions.checks` caches calls to `User.has_perm` for the life of a
+request. To ensure fresh results between requests, add the middleware to your
+`MIDDLEWARE` setting:
+
+```python
+MIDDLEWARE = [
+    # ...
+    "apps.permissions.middleware.PermissionCacheMiddleware",
+]
+```
+
+## Permission Template Tags
 
 This project exposes template tags that mirror the utilities in
 `apps.permissions.checks`. They allow model-, instance-, and field-level

--- a/mag360/settings.py
+++ b/mag360/settings.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'apps.permissions.middleware.PermissionCacheMiddleware',
 ]
 
 ROOT_URLCONF = 'mag360.urls'


### PR DESCRIPTION
## Summary
- avoid reusing permission cache across requests
- add middleware to reset permission cache after each request
- document middleware usage

## Testing
- `python -m py_compile apps/permissions/checks.py apps/permissions/middleware.py`
- `python manage.py test apps.permissions.tests` *(fails: ModuleNotFoundError: No module named 'dal')*
- `pip install django-autocomplete-light` *(fails: Could not find a version that satisfies the requirement django-autocomplete-light)*

------
https://chatgpt.com/codex/tasks/task_e_689d3bcd8dc48330a9b8963cf8957821