### PR TITLE
feat: add app and model filters for field permission rebuild

### DIFF
--- a/apps/permissions/management/commands/rebuild_field_permissions.py
+++ b/apps/permissions/management/commands/rebuild_field_permissions.py
@@ -4,17 +4,56 @@ from apps.permissions.utils import generate_field_permissions_for_model
 
 
 class Command(BaseCommand):
-    help = "Rebuild field-level permissions for all models."
+    help = (
+        "Rebuild field-level permissions for all models or a specific app/model."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--app",
+            help="App label to limit which models are processed.",
+        )
+        parser.add_argument(
+            "--model",
+            help="Model name to limit processing to. Requires --app.",
+        )
 
     def handle(self, *args, **options):
-        created_count = 0
+        app_label = options.get("app")
+        model_name = options.get("model")
+
         try:
-            for model in django_apps.get_models():
+            if model_name and not app_label:
+                raise CommandError("--model option requires --app.")
+
+            if app_label:
+                try:
+                    app_config = django_apps.get_app_config(app_label)
+                except LookupError:
+                    raise CommandError(f"App '{app_label}' not found.")
+
+                if model_name:
+                    try:
+                        models = [app_config.get_model(model_name)]
+                    except LookupError:
+                        raise CommandError(
+                            f"Model '{model_name}' not found in app '{app_label}'."
+                        )
+                else:
+                    models = app_config.get_models()
+            else:
+                models = django_apps.get_models()
+
+            created_count = 0
+            for model in models:
                 created_count += generate_field_permissions_for_model(model)
+
             self.stdout.write(
                 self.style.SUCCESS(
                     f"Field permissions rebuilt. Created {created_count} permissions."
                 )
             )
+        except CommandError:
+            raise
         except Exception as exc:
             raise CommandError(f"Error rebuilding field permissions: {exc}")

--- a/apps/permissions/tests.py
+++ b/apps/permissions/tests.py
@@ -2,8 +2,11 @@ from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from django.core.management import CommandError, call_command
+from django.apps import apps as django_apps
 from django.test import TestCase
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from apps.permissions.checks import get_editable_fields, get_readable_fields
 from apps.permissions.forms import PermissionFormMixin
@@ -63,4 +66,37 @@ class M2MPermissionsTests(TestCase):
         form = UserForm(user=user_read_only)
         self.assertIn("groups", form.fields)
         self.assertTrue(form.fields["groups"].disabled)
+
+
+class RebuildFieldPermissionsCommandTests(TestCase):
+    def test_model_requires_app(self):
+        with self.assertRaises(CommandError):
+            call_command("rebuild_field_permissions", model="User")
+
+    def test_invalid_app(self):
+        with self.assertRaises(CommandError):
+            call_command("rebuild_field_permissions", app="invalid")
+
+    def test_invalid_model(self):
+        with self.assertRaises(CommandError):
+            call_command("rebuild_field_permissions", app="auth", model="Nope")
+
+    @patch(
+        "apps.permissions.management.commands.rebuild_field_permissions.generate_field_permissions_for_model",
+        return_value=0,
+    )
+    def test_specific_model(self, mock_generate):
+        call_command("rebuild_field_permissions", app="auth", model="User")
+        user_model = django_apps.get_model("auth", "User")
+        mock_generate.assert_called_once_with(user_model)
+
+    @patch(
+        "apps.permissions.management.commands.rebuild_field_permissions.generate_field_permissions_for_model",
+        return_value=0,
+    )
+    def test_app_only(self, mock_generate):
+        call_command("rebuild_field_permissions", app="auth")
+        auth_models = list(django_apps.get_app_config("auth").get_models())
+        called_models = [call.args[0] for call in mock_generate.call_args_list]
+        self.assertCountEqual(auth_models, called_models)
 


### PR DESCRIPTION
## Summary
- allow rebuilding field permissions for a single app or model via new `--app` and `--model` options
- add tests covering valid and invalid app/model combinations

## Testing
- `python manage.py test` *(fails: No module named 'dal')*


------
https://chatgpt.com/codex/tasks/task_e_689d461d3e7483309b1b7c43b73b4abb