### PR TITLE
Clear permission cache on request finish

### DIFF
--- a/apps/permissions/apps.py
+++ b/apps/permissions/apps.py
@@ -1,4 +1,12 @@
 from django.apps import AppConfig
+from django.core.signals import request_finished
+
+from .checks import clear_perm_cache
+
+
+def _clear_perm_cache(**kwargs):
+    """Signal handler to clear the permission cache."""
+    clear_perm_cache()
 
 
 class PermissionsConfig(AppConfig):
@@ -7,3 +15,6 @@ class PermissionsConfig(AppConfig):
 
     def ready(self):
         import apps.permissions.signals
+        request_finished.connect(
+            _clear_perm_cache, dispatch_uid="apps.permissions.clear_perm_cache"
+        )

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,10 +1,13 @@
 # Permissions
 
-## Cache-clearing middleware
+## Cache clearing
 
 `apps.permissions.checks` caches calls to `User.has_perm` for the life of a
-request. To ensure fresh results between requests, add the middleware to your
-`MIDDLEWARE` setting:
+request. To avoid cache leakage between requests you must clear this cache
+either via Django's `request_finished` signal or by using the middleware.
+The signal hook is registered automatically when `apps.permissions` is in
+`INSTALLED_APPS`. If you prefer middleware, add it to your `MIDDLEWARE`
+setting:
 
 ```python
 MIDDLEWARE = [
@@ -12,6 +15,9 @@ MIDDLEWARE = [
     "apps.permissions.middleware.PermissionCacheMiddleware",
 ]
 ```
+
+Either the middleware or the signal hook must be enabled to prevent
+unbounded cache growth.
 
 ## Permission Template Tags
 


### PR DESCRIPTION
## Summary
- Clear permission cache on Django `request_finished` using AppConfig signal hookup
- Explain that either the signal hook or middleware is required to prevent cache leakage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d48a1fb748330b85dedd4c6297dc6