### PR TITLE
Remove unused permission user attribute

### DIFF
--- a/apps/permissions/forms/permission_form_mixin.py
+++ b/apps/permissions/forms/permission_form_mixin.py
@@ -12,8 +12,6 @@ class PermissionFormMixin:
 
         if not user:
             raise ValueError("PermissionFormMixin requires a 'user' argument")
-
-        self._permission_user = user
         model = self._meta.model
         instance = instance or getattr(self, 'instance', None)
 


### PR DESCRIPTION
## Summary
- Stop storing the user on `PermissionFormMixin` and rely solely on direct calls to permission helpers

## Testing
- `python manage.py test apps.permissions` *(fails: django.core.exceptions.ImproperlyConfigured: Set the SECRET_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689d4a9892208330a24c70a176105045