### PR TITLE
Skip auto-created and non-editable fields in permission checks

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -152,7 +152,11 @@ def can_write_field(user, model, field_name, instance=None):
 def _get_fields_by_action(user, model, action, instance=None):
     """Return names of model fields the user may act on for ``action``."""
 
-    fields = list(model._meta.fields) + list(model._meta.many_to_many)
+    fields = [
+        field
+        for field in list(model._meta.fields) + list(model._meta.many_to_many)
+        if not field.auto_created and field.editable
+    ]
 
     if user.is_superuser or user.is_staff:
         return [field.name for field in fields]


### PR DESCRIPTION
## Summary
- Avoid `has_perm` checks for auto-created or non-editable model fields
- Add regression test ensuring field filtering skips unnecessary permission lookups

## Testing
- `SECRET_KEY=foo ALLOWED_HOSTS='*' DATABASE_NAME=name DATABASE_USER=user DATABASE_PASS=pass DATABASE_HOST=localhost DATABASE_PORT=5432 EMAIL_HOST=localhost DEFAULT_FROM_EMAIL=test@example.com ADMINS=test@example.com python manage.py test apps.permissions.tests.FieldFilteringTests -v 2` *(fails: ModuleNotFoundError: No module named 'dal')*

------
https://chatgpt.com/codex/tasks/task_e_689d4e9dc56483308ce9270c61224399