### PR TITLE
Handle disabled fields properly in PermissionFormMixin

### DIFF
--- a/apps/permissions/forms/permission_form_mixin.py
+++ b/apps/permissions/forms/permission_form_mixin.py
@@ -24,3 +24,5 @@ class PermissionFormMixin:
                 del self.fields[name]
             elif name not in editable:
                 field.disabled = True
+                # Disabled fields must not be required so form validation passes
+                field.required = False


### PR DESCRIPTION
## Summary
- Mark disabled fields as not required to avoid validation errors
- Document why disabled fields must be optional in forms

## Testing
- `pytest` *(no tests found)*
- `SECRET_KEY=dummy python manage.py test apps.permissions` *(fails: Set the ALLOWED_HOSTS environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689d4ff36bdc8330952cc02b4f901237