### PR TITLE
Validate request presence in permission template tags

### DIFF
--- a/apps/permissions/templatetags/permissions_tags.py
+++ b/apps/permissions/templatetags/permissions_tags.py
@@ -18,10 +18,16 @@ def _user_and_obj(context, user_or_obj, obj=None):
     """Return a ``(user, obj)`` tuple.
 
     When ``obj`` is ``None`` the first positional argument is treated as
-    ``obj`` and ``context['request'].user`` is used for the user.
+    ``obj`` and ``context['request'].user`` is used for the user. The template
+    context must include ``request`` when the user argument is omitted.
     """
 
     if obj is None:
+        if "request" not in context:
+            raise ValueError(
+                "Template context does not include 'request'; pass a user "
+                "explicitly."
+            )
         user = context["request"].user
         obj = user_or_obj
     else:
@@ -33,7 +39,8 @@ def _user_model_field_instance(context, *args):
     """Return ``(user, model, field_name, instance)`` from ``args``.
 
     The ``user`` argument is optional; when omitted the current request user is
-    used. The ``instance`` argument remains optional.
+    used. The ``instance`` argument remains optional. The template context must
+    include ``request`` when the user argument is omitted.
     """
 
     if args and hasattr(args[0], "is_authenticated"):
@@ -42,6 +49,11 @@ def _user_model_field_instance(context, *args):
         field_name = args[2]
         instance = args[3] if len(args) > 3 else None
     else:
+        if "request" not in context:
+            raise ValueError(
+                "Template context does not include 'request'; pass a user "
+                "explicitly."
+            )
         user = context["request"].user
         model = args[0]
         field_name = args[1]

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -53,7 +53,9 @@ UI elements.
 All of these tags delegate to similarly named functions in
 `apps.permissions.checks` and return booleans indicating whether the request's
 user has the requisite permission. If you need to check permissions for a
-different user, pass them as the first argument to the tag.
+different user, pass them as the first argument to the tag. When omitting the
+user argument, the template context must include ``request`` so the current
+user can be inferred; otherwise pass the user explicitly.
 
 ## View Mixins
 


### PR DESCRIPTION
## Summary
- ensure permission template tag helpers raise a clear error when `request` is missing from context
- document that omitting the `user` argument requires `request` in the template context

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'dal')*
- `pip install django-autocomplete-light` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d50d9ea288330adea0cea4c8463e4