### PR TITLE
Cleanup field-level permissions

### DIFF
--- a/apps/permissions/management/commands/rebuild_field_permissions.py
+++ b/apps/permissions/management/commands/rebuild_field_permissions.py
@@ -45,12 +45,16 @@ class Command(BaseCommand):
                 models = django_apps.get_models()
 
             created_count = 0
+            deleted_count = 0
             for model in models:
-                created_count += generate_field_permissions_for_model(model)
+                created, deleted = generate_field_permissions_for_model(model)
+                created_count += created
+                deleted_count += deleted
 
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"Field permissions rebuilt. Created {created_count} permissions."
+                    "Field permissions rebuilt. "
+                    f"Created {created_count} and deleted {deleted_count} permissions."
                 )
             )
         except CommandError:

--- a/apps/permissions/utils.py
+++ b/apps/permissions/utils.py
@@ -6,41 +6,50 @@ def generate_field_permissions_for_model(model):
     """Ensure view/change permissions exist for each editable field of ``model``.
 
     Iterates over both concrete fields and explicit many-to-many relations while
-    skipping auto-created or non-editable fields. Returns the number of
-    permissions created.
+    skipping auto-created or non-editable fields. Returns a tuple of the number
+    of permissions created and deleted, respectively.
     """
 
-    created_count = 0
     ct = ContentType.objects.get_for_model(model)
     model_name = model._meta.model_name
     verbose_name = model._meta.verbose_name.title()
 
+    # Determine expected permissions for each editable field
+    expected_perms = {}
     for field in list(model._meta.fields) + list(model._meta.many_to_many):
         if field.auto_created or not field.editable:
             continue
         field_name = field.name
-
-        # READ permission
-        codename_r = f"view_{model_name}_{field_name}"
-        name_r = f'Can view field "{field_name}" on Model "{verbose_name}"'
-        _, created = Permission.objects.get_or_create(
-            codename=codename_r,
-            content_type=ct,
-            defaults={"name": name_r},
+        expected_perms[f"view_{model_name}_{field_name}"] = (
+            f'Can view field "{field_name}" on Model "{verbose_name}"'
         )
-        if created:
-            created_count += 1
-
-        # WRITE permission
-        codename_w = f"change_{model_name}_{field_name}"
-        name_w = f'Can change field "{field_name}" on Model "{verbose_name}"'
-        _, created = Permission.objects.get_or_create(
-            codename=codename_w,
-            content_type=ct,
-            defaults={"name": name_w},
+        expected_perms[f"change_{model_name}_{field_name}"] = (
+            f'Can change field "{field_name}" on Model "{verbose_name}"'
         )
-        if created:
-            created_count += 1
 
-    return created_count
+    # Collect existing field-level permissions for this model
+    existing_qs = Permission.objects.filter(
+        content_type=ct,
+        codename__regex=rf"^(view|change)_{model_name}_.+",
+    )
+    existing_codenames = set(existing_qs.values_list("codename", flat=True))
+
+    # Delete permissions for fields no longer present
+    to_delete = existing_codenames - expected_perms.keys()
+    deleted_count = 0
+    if to_delete:
+        deleted_count, _ = Permission.objects.filter(
+            content_type=ct, codename__in=to_delete
+        ).delete()
+
+    # Bulk-create any missing permissions
+    to_create = [
+        Permission(codename=codename, name=name, content_type=ct)
+        for codename, name in expected_perms.items()
+        if codename not in existing_codenames
+    ]
+    created_objs = Permission.objects.bulk_create(to_create)
+    created_count = len(created_objs)
+
+    return created_count, deleted_count
 


### PR DESCRIPTION
## Summary
- bulk-generate field level permissions for models
- remove obsolete field permissions
- track counts of created and deleted permissions

## Testing
- `python manage.py test` *(fails: Set the EMAIL_HOST environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_689e59681af88330a33e5afea377e17f