### PR TITLE
Optimize field permission checks

### DIFF
--- a/apps/permissions/checks.py
+++ b/apps/permissions/checks.py
@@ -176,10 +176,23 @@ def _get_fields_by_action(user, model, action, instance=None):
     if user.is_superuser or user.is_staff:
         return [field.name for field in fields]
 
+    if action == "view":
+        if not can_view_model(user, model):
+            return []
+        if instance and not can_view_instance(user, instance):
+            return []
+    elif action == "change":
+        if not can_change_model(user, model):
+            return []
+        if instance and not can_change_instance(user, instance):
+            return []
+    else:
+        raise ValueError(f"Unsupported action: {action}")
+
     return [
         field.name
         for field in fields
-        if can_act_on_field(user, model, field.name, action, instance)
+        if _cached_has_perm(user, _get_perm_codename(model, field.name, action))
     ]
 
 def get_readable_fields(user, model, instance=None):


### PR DESCRIPTION
## Summary
- Avoid repeated model and instance permission checks when retrieving field permissions
- Use `_cached_has_perm` directly for field-level permission evaluation

## Testing
- `DJANGO_SETTINGS_MODULE=mag360.settings pytest apps/permissions/tests.py -q` *(fails: Set the DATABASE_NAME environment variable)*
- `DJANGO_SETTINGS_MODULE=mag360.test_settings pytest apps/permissions/tests.py -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_689e5f87122c833093ea0ab65bb467e5