### PR TITLE
Scope field permission generation to app configs

### DIFF
--- a/apps/permissions/signals/generate_field_permissions.py
+++ b/apps/permissions/signals/generate_field_permissions.py
@@ -1,14 +1,17 @@
-from django.apps import apps as django_apps
+from django.apps import AppConfig
 from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 
 from apps.permissions.utils import generate_field_permissions_for_model
 
 
-@receiver(post_migrate)
-def generate_field_permissions(sender, **kwargs):
+@receiver(post_migrate, dispatch_uid="apps.permissions.generate_field_permissions")
+def generate_field_permissions(sender: AppConfig | None, **kwargs) -> None:
     """Ensure view/change permissions exist for each model's fields after migrations."""
 
-    for model in django_apps.get_models():
+    if not isinstance(sender, AppConfig):
+        return
+
+    for model in sender.get_models():
         generate_field_permissions_for_model(model)
 


### PR DESCRIPTION
## Summary
- Iterate over models on the `post_migrate` sender instead of all registered models
- Support `AppConfig` senders and use a `dispatch_uid` to avoid duplicate signal registration

## Testing
- `pytest apps/permissions`
- `flake8 apps/permissions/signals/generate_field_permissions.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e6198220483308fd4868a49852ca0