### PR TITLE
Use capfirst for verbose model names

### DIFF
--- a/apps/permissions/utils.py
+++ b/apps/permissions/utils.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
+from django.utils.text import capfirst
 
 
 def generate_field_permissions_for_model(model):
@@ -13,7 +14,7 @@ def generate_field_permissions_for_model(model):
 
     ct = ContentType.objects.get_for_model(model)
     model_name = model._meta.model_name
-    verbose_name = model._meta.verbose_name.title()
+    verbose_name = capfirst(model._meta.verbose_name)
 
     # Determine expected permissions for each editable field
     expected_perms = {}


### PR DESCRIPTION
## Summary
- Use `capfirst` to normalize model verbose names when generating field permissions

## Testing
- `python manage.py test` *(fails: No module named 'dal')*


------
https://chatgpt.com/codex/tasks/task_e_689e6b924f1883308f4bcc35a35edba2