### PR TITLE
Handle proxy and abstract models in field permission generation

### DIFF
--- a/apps/permissions/tests.py
+++ b/apps/permissions/tests.py
@@ -177,3 +177,39 @@ class FieldPermissionCleanupTests(TestCase):
             ).exists()
         )
 
+
+class ProxyAndAbstractModelTests(TestCase):
+    def test_returns_zero_for_proxy_model(self):
+        class Base(models.Model):
+            name = models.CharField(max_length=10)
+
+            class Meta:
+                app_label = "tests"
+
+        class Proxy(Base):
+            class Meta:
+                app_label = "tests"
+                proxy = True
+
+        with patch(
+            "apps.permissions.utils.ContentType.objects.get_for_model"
+        ) as mock_get_for_model:
+            created, deleted = generate_field_permissions_for_model(Proxy)
+        self.assertEqual((created, deleted), (0, 0))
+        mock_get_for_model.assert_not_called()
+
+    def test_returns_zero_for_abstract_model(self):
+        class Abstract(models.Model):
+            name = models.CharField(max_length=10)
+
+            class Meta:
+                app_label = "tests"
+                abstract = True
+
+        with patch(
+            "apps.permissions.utils.ContentType.objects.get_for_model"
+        ) as mock_get_for_model:
+            created, deleted = generate_field_permissions_for_model(Abstract)
+        self.assertEqual((created, deleted), (0, 0))
+        mock_get_for_model.assert_not_called()
+

--- a/apps/permissions/utils.py
+++ b/apps/permissions/utils.py
@@ -12,7 +12,10 @@ def generate_field_permissions_for_model(model):
     of permissions created and deleted, respectively.
     """
 
-    ct = ContentType.objects.get_for_model(model)
+    if model._meta.proxy or model._meta.abstract:
+        return 0, 0
+
+    ct = ContentType.objects.get_for_model(model, for_concrete_model=False)
     model_name = model._meta.model_name
     verbose_name = capfirst(model._meta.verbose_name)
 


### PR DESCRIPTION
## Summary
- skip field permission generation for proxy or abstract models
- ensure ContentType lookup allows proxy models
- add tests covering proxy and abstract model cases

## Testing
- `DJANGO_SETTINGS_MODULE=mag360.test_settings python manage.py test apps.permissions -v 2`

------
https://chatgpt.com/codex/tasks/task_e_689e6f1873108330a1bf50fefc2ea0b2