### PR TITLE
Remove signal-based permission cache clearing

### DIFF
--- a/apps/permissions/apps.py
+++ b/apps/permissions/apps.py
@@ -1,12 +1,4 @@
 from django.apps import AppConfig
-from django.core.signals import request_finished
-
-from .checks import clear_perm_cache
-
-
-def _clear_perm_cache(**kwargs):
-    """Signal handler to clear the permission cache."""
-    clear_perm_cache()
 
 
 class PermissionsConfig(AppConfig):
@@ -15,6 +7,3 @@ class PermissionsConfig(AppConfig):
 
     def ready(self):
         import apps.permissions.signals
-        request_finished.connect(
-            _clear_perm_cache, dispatch_uid="apps.permissions.clear_perm_cache"
-        )

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -4,10 +4,7 @@
 
 `apps.permissions.checks` caches calls to `User.has_perm` for the life of a
 request. To avoid cache leakage between requests you must clear this cache
-either via Django's `request_finished` signal or by using the middleware.
-The signal hook is registered automatically when `apps.permissions` is in
-`INSTALLED_APPS`. If you prefer middleware, add it to your `MIDDLEWARE`
-setting:
+using the middleware. Add it to your `MIDDLEWARE` setting:
 
 ```python
 MIDDLEWARE = [
@@ -16,8 +13,8 @@ MIDDLEWARE = [
 ]
 ```
 
-Either the middleware or the signal hook must be enabled to prevent
-unbounded cache growth.
+Without the middleware, permission checks will accumulate indefinitely,
+leading to unbounded cache growth.
 
 ## Temporarily disabling the cache
 


### PR DESCRIPTION
## Summary
- remove request_finished signal hook for permission cache clearing
- update docs to recommend middleware for cache clearing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e725048948330bdbcdfeb3450b2d3