### PR TITLE
Preload Tom Select filter options

### DIFF
--- a/apps/blocks/templates/components/filter_fields.html
+++ b/apps/blocks/templates/components/filter_fields.html
@@ -70,7 +70,7 @@
     if (el.dataset.tomInitialized) return;
     el.dataset.tomInitialized = '1';
     const ajaxUrl = el.dataset.ajaxUrl;
-    const settings = {persist: false};
+    const settings = {persist: false, maxOptions: 100};
     if (el.multiple) {
       settings.plugins = ['remove_button'];
     }
@@ -78,6 +78,8 @@
       settings.valueField = 'value';
       settings.labelField = 'label';
       settings.searchField = 'label';
+      settings.preload = true;
+      settings.shouldLoad = () => true;
       settings.load = function(query, callback){
         const url = ajaxUrl + (query ? ('?q=' + encodeURIComponent(query)) : '');
         fetch(url).then(r => r.json()).then(callback).catch(() => callback());


### PR DESCRIPTION
## Summary
- preload up to 100 options for Tom Select AJAX filters so users see initial choices immediately

## Testing
- `python manage.py test` *(fails: No module named 'crispy_bootstrap5')*


------
https://chatgpt.com/codex/tasks/task_e_68af0e3101148330a45ceea0cc9b838a