### PR TITLE
Allow custom Tom Select options in filters

### DIFF
--- a/apps/blocks/documentation.md
+++ b/apps/blocks/documentation.md
@@ -58,9 +58,10 @@ Both table and chart partials include a “Manage Filters” link and dynamic fi
 ## Filters (shared)
 
 - Schema driven via `FilterResolutionMixin` (`block_types/table/filter_utils.py`).
-- Schema format (per key): `{ type, label, choices? }` where:
+- Schema format (per key): `{ type, label, choices?, tom_select_options? }` where:
   - `type`: `text` (default), `select`, `multiselect`, `boolean`.
   - `choices`: list or callable(user) → list for select/multiselect.
+  - `tom_select_options`: optional dict of Tom Select settings merged into defaults.
 - Resolution: `_resolve_filter_schema` normalizes types and resolves callable choices.
 - Collection: `_collect_filters(qd, schema, base, prefix, allow_flat)` extracts values from request data, merging with saved config defaults.
 - GET namespacing: keys look like `"<block>__<instance>__filters.<name>"` when embedded, or `"<block>__filters.<name>"` otherwise.

--- a/apps/blocks/templates/components/filter_fields.html
+++ b/apps/blocks/templates/components/filter_fields.html
@@ -1,5 +1,5 @@
 {# expects:
-   - filter_schema: dict of key -> {label, type, help?, choices?, multiple?}
+   - filter_schema: dict of key -> {label, type, help?, choices?, multiple?, tom_select_options?}
    - initial_values: dict of key -> value (or list for multiselect)
 #}
 {% load dict_extras static %}
@@ -10,7 +10,7 @@
     <label class="form-label">{{ cfg.label }}</label>
 
     {% if cfg.type == 'select' %}
-      <select class="form-select filter-field-select" name="{{ name_prefix|default:'filters.' }}{{ key }}"{% if cfg.choices_url %} data-ajax-url="{{ cfg.choices_url }}"{% endif %}>
+      <select class="form-select filter-field-select" name="{{ name_prefix|default:'filters.' }}{{ key }}"{% if cfg.choices_url %} data-ajax-url="{{ cfg.choices_url }}"{% endif %}{% if cfg.tom_select_options %} data-tom-select-options='{{ cfg.tom_select_options|tojson }}'{% endif %}>
         <option value="">-- Any --</option>
         {% if not cfg.choices_url %}
           {% for v, lbl in cfg.choices %}
@@ -25,7 +25,7 @@
       </select>
 
     {% elif cfg.type == 'multiselect' %}
-      <select class="form-select filter-field-select" name="{{ name_prefix|default:'filters.' }}{{ key }}" multiple{% if cfg.choices_url %} data-ajax-url="{{ cfg.choices_url }}"{% endif %}>
+      <select class="form-select filter-field-select" name="{{ name_prefix|default:'filters.' }}{{ key }}" multiple{% if cfg.choices_url %} data-ajax-url="{{ cfg.choices_url }}"{% endif %}{% if cfg.tom_select_options %} data-tom-select-options='{{ cfg.tom_select_options|tojson }}'{% endif %}>
         {% if not cfg.choices_url %}
           {% for v, lbl in cfg.choices %}
             <option value="{{ v }}" {% if val and v in val %}selected{% endif %}>
@@ -85,6 +85,7 @@
         fetch(url).then(r => r.json()).then(callback).catch(() => callback());
       };
     }
-    new TomSelect(el, settings);
+    const extraOpts = el.dataset.tomSelectOptions ? JSON.parse(el.dataset.tomSelectOptions) : {};
+    new TomSelect(el, { ...settings, ...extraOpts });
   });
 </script>

--- a/apps/common/templatetags/dict_extras.py
+++ b/apps/common/templatetags/dict_extras.py
@@ -1,4 +1,6 @@
 from django import template
+import json
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -8,3 +10,12 @@ def get_item(d, key):
         return d.get(key)
     except Exception:
         return None
+
+
+@register.filter
+def tojson(value):
+    """Serialize a Python object to JSON for embedding in templates."""
+    try:
+        return mark_safe(json.dumps(value))
+    except Exception:
+        return mark_safe("null")

--- a/apps/production/blocks.py
+++ b/apps/production/blocks.py
@@ -89,6 +89,10 @@ class ProductionOrderTableBlock(TableBlock):
                 "multiple": True,
                 "choices": item_choices,
                 "choices_url": reverse("block_filter_choices", args=[self.block_name, "item"]),
+                "tom_select_options": {
+                    "placeholder": "Search items...",
+                    "plugins": ["remove_button"],
+                },
                 "handler": lambda qs, val: qs.filter(item__code__in=val) if val else qs,
             },
         }


### PR DESCRIPTION
## Summary
- add `tojson` template filter to serialize values
- allow passing `tom_select_options` in filter schemas and merge into TomSelect initialization
- document `tom_select_options` in block filter schema
- demonstrate `tom_select_options` with placeholder and plugin in ProductionOrderTableBlock item filter

## Testing
- `DJANGO_SETTINGS_MODULE=mag360.test_settings pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af153ec29083309f9834a7d8c03fb2