### PR TITLE
Clear Tom Select search input after selection

### DIFF
--- a/apps/blocks/templates/components/filter_fields.html
+++ b/apps/blocks/templates/components/filter_fields.html
@@ -86,6 +86,7 @@
       };
     }
     const extraOpts = el.dataset.tomSelectOptions ? JSON.parse(el.dataset.tomSelectOptions) : {};
-    new TomSelect(el, { ...settings, ...extraOpts });
+    const ts = new TomSelect(el, { ...settings, ...extraOpts });
+    ts.on('item_add', () => ts.setTextboxValue(''));
   });
 </script>


### PR DESCRIPTION
## Summary
- Ensure Tom Select filter inputs clear the search text after choosing an option

## Testing
- `npm test` *(fails: Missing script "test")*
- `python -m pytest` *(fails: Requested setting LOGGING_CONFIG, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68af2236d8e88330bd215196a2e60d5c