### PR TITLE
Fix region choice list for SalesByMonthChart

### DIFF
--- a/apps/production/charts.py
+++ b/apps/production/charts.py
@@ -28,7 +28,7 @@ class SalesByMonthChart(BarChartBlock):
 
     def get_filter_schema(self, user):
         def order_choices(user, query=""):
-            return [("all", "All"), ("na", "North America"), ("eu", "Europe")],
+            return [("all", "All"), ("na", "North America"), ("eu", "Europe")]
 
 
         # Fake region selector; not used in the static data


### PR DESCRIPTION
## Summary
- fix tuple return so region choices are static list

## Testing
- `DJANGO_SETTINGS_MODULE=mag360.test_settings pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af2ca546e88330b4c38dd27499fe97