### PR TITLE
Add fixed region filter to SalesByMonthChart

### DIFF
--- a/apps/production/charts.py
+++ b/apps/production/charts.py
@@ -1,5 +1,4 @@
 from apps.blocks.block_types.chart.chart_block import DonutChartBlock, BarChartBlock, LineChartBlock
-from django.urls import reverse
 
 class ProductionOrdersByStatusChart(DonutChartBlock):
     def __init__(self):
@@ -27,20 +26,20 @@ class SalesByMonthChart(BarChartBlock):
         )
 
     def get_filter_schema(self, user):
-        def order_choices(user, query=""):
-            return [("all", "All"), ("na", "North America"), ("eu", "Europe")]
-
-
-        # Fake region selector; not used in the static data
+        # Fixed region selector; options are static so we don't need a choices_url
         return {
             "region": {
                 "label": "Region",
                 "type": "select",
-                "choices": order_choices,
-                "choices_url": reverse("block_filter_choices", args=[self.block_name, "production_order"]),
-                # "handler": lambda qs, val: qs.filter(production_order=val) if val else qs,
+                "choices": [
+                    ("all", "All"),
+                    ("na", "North America"),
+                    ("eu", "Europe"),
+                ],
+                # Use Tom Select with fixed values and no option creation
                 "tom_select_options": {
                     "placeholder": "Search regions...",
+                    "create": False,
                 },
             },
         }

--- a/apps/production/test_charts.py
+++ b/apps/production/test_charts.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+import django
+
+django.setup()
+
+from apps.production.charts import SalesByMonthChart
+
+
+class SalesByMonthChartTests(SimpleTestCase):
+    def setUp(self):
+        self.chart = SalesByMonthChart()
+
+    def test_region_filter_has_fixed_choices(self):
+        schema = self.chart.get_filter_schema(None)
+        region_cfg = schema.get("region")
+        self.assertIsNotNone(region_cfg)
+        self.assertEqual(region_cfg.get("type"), "select")
+        self.assertEqual(
+            region_cfg.get("choices"),
+            [("all", "All"), ("na", "North America"), ("eu", "Europe")],
+        )
+        self.assertNotIn("choices_url", region_cfg)
+        opts = region_cfg.get("tom_select_options")
+        self.assertIsNotNone(opts)
+        self.assertFalse(opts.get("create"))


### PR DESCRIPTION
## Summary
- use Tom Select with static region values in SalesByMonthChart
- add unit test covering region filter options

## Testing
- `python manage.py test --settings=mag360.test_settings` (fails: no such table)
- `DJANGO_SETTINGS_MODULE=mag360.test_settings python -m unittest apps.production.test_charts`


------
https://chatgpt.com/codex/tasks/task_e_68af2d81e1d88330a2e9a42f48987eb5