### PR TITLE
Add production order charts with status filters

### DIFF
--- a/apps/production/blocks_registry.py
+++ b/apps/production/blocks_registry.py
@@ -2,7 +2,11 @@ from apps.production.blocks import (
     ProductionOrderTableBlock,
     ProductionOrderOperationTableBlock,
 )
-from apps.production.charts import ProductionOrdersByStatusChart, SalesByMonthChart, ActiveUsersOverTimeChart
+from apps.production.charts import (
+    ProductionOrdersByStatusChart,
+    ProductionOrdersPerItemBarChart,
+    ProductionOrdersPerItemLineChart,
+)
 
 
 def register(registry):
@@ -11,7 +15,7 @@ def register(registry):
     registry.register("production_order_table", ProductionOrderTableBlock())
     registry.register("production_order_operation_table", ProductionOrderOperationTableBlock())
     registry.register("prod_orders_by_status", ProductionOrdersByStatusChart())
-    registry.register("sales_by_month", SalesByMonthChart())
-    registry.register("active_users_over_time", ActiveUsersOverTimeChart())
+    registry.register("prod_orders_per_item_bar", ProductionOrdersPerItemBarChart())
+    registry.register("prod_orders_per_item_line", ProductionOrdersPerItemLineChart())
 
 

--- a/apps/production/test_charts.py
+++ b/apps/production/test_charts.py
@@ -1,25 +1,53 @@
-from django.test import SimpleTestCase
+from django.test import TestCase
 import django
 
 django.setup()
 
-from apps.production.charts import SalesByMonthChart
+from apps.production.charts import (
+    ProductionOrdersByStatusChart,
+    ProductionOrdersPerItemBarChart,
+    ProductionOrdersPerItemLineChart,
+)
+from apps.common.models import ProductionOrder, Item
 
 
-class SalesByMonthChartTests(SimpleTestCase):
+class ProductionChartsTests(TestCase):
     def setUp(self):
-        self.chart = SalesByMonthChart()
+        self.status_chart = ProductionOrdersByStatusChart()
+        self.bar_chart = ProductionOrdersPerItemBarChart()
+        self.line_chart = ProductionOrdersPerItemLineChart()
 
-    def test_region_filter_has_fixed_choices(self):
-        schema = self.chart.get_filter_schema(None)
-        region_cfg = schema.get("region")
-        self.assertIsNotNone(region_cfg)
-        self.assertEqual(region_cfg.get("type"), "select")
-        self.assertEqual(
-            region_cfg.get("choices"),
-            [("all", "All"), ("na", "North America"), ("eu", "Europe")],
+        item1 = Item.objects.create(code="ITM1")
+        item2 = Item.objects.create(code="ITM2")
+
+        ProductionOrder.objects.create(
+            production_order="PO1", status="open", item=item1
         )
-        self.assertNotIn("choices_url", region_cfg)
-        opts = region_cfg.get("tom_select_options")
-        self.assertIsNotNone(opts)
-        self.assertFalse(opts.get("create"))
+        ProductionOrder.objects.create(
+            production_order="PO2", status="open", item=item1
+        )
+        ProductionOrder.objects.create(
+            production_order="PO3", status="closed", item=item2
+        )
+
+    def test_status_filter_schema_is_multiselect(self):
+        schema = self.status_chart.get_filter_schema(None)
+        cfg = schema.get("status")
+        self.assertIsNotNone(cfg)
+        self.assertEqual(cfg.get("type"), "multiselect")
+
+    def test_donut_chart_counts_by_status(self):
+        data = self.status_chart.get_chart_data(None, {})
+        self.assertEqual(data["labels"], ["closed", "open"])
+        self.assertEqual(data["values"], [1, 2])
+
+    def test_bar_chart_filters_by_status(self):
+        data = self.bar_chart.get_chart_data(None, {"status": ["open"]})
+        self.assertEqual(data["x"], ["ITM1"])
+        self.assertEqual(data["y"], [2])
+
+    def test_line_chart_returns_all_items(self):
+        data = self.line_chart.get_chart_data(None, {})
+        self.assertEqual(data["x"], ["ITM1", "ITM2"])
+        self.assertEqual(data["y"], [2, 1])
+


### PR DESCRIPTION
## Summary
- add donut chart for production orders by status
- show bar and line charts of production orders per item with optional status filter
- cover new chart blocks with tests

## Testing
- `python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mag360.test_settings')
import django
from django.test.utils import get_runner
from django.conf import settings

django.setup()

TestRunner = get_runner(settings)
runner = TestRunner()
failures = runner.run_tests(['apps.production'])
print('failures', failures)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68af46b3448c8330a9952caff35584fe