### PR TITLE
Integrate permission checks into chart blocks

### DIFF
--- a/apps/production/charts.py
+++ b/apps/production/charts.py
@@ -15,6 +15,7 @@ class _StatusFilterMixin:
     def _status_filter_schema(self):
         def status_choices(user, query=""):
             qs = ProductionOrder.objects.all()
+            qs = self.filter_queryset(user, qs)
             if query:
                 qs = qs.filter(status__icontains=query)
             statuses = (
@@ -33,6 +34,8 @@ class _StatusFilterMixin:
                 "choices_url": reverse(
                     "block_filter_choices", args=[self.block_name, "status"]
                 ),
+                "model": ProductionOrder,
+                "field": "status",
                 "tom_select_options": {
                     "placeholder": "Search status...",
                     "plugins": ["remove_button"],
@@ -51,7 +54,7 @@ class ProductionOrdersByStatusChart(_StatusFilterMixin, DonutChartBlock):
         return self._status_filter_schema()
 
     def get_chart_data(self, user, filters):
-        qs = ProductionOrder.objects.all()
+        qs = self.filter_queryset(user, ProductionOrder.objects.all())
         statuses = filters.get("status")
         if statuses:
             qs = qs.filter(status__in=statuses)
@@ -82,7 +85,7 @@ class ProductionOrdersPerItemBarChart(_StatusFilterMixin, BarChartBlock):
         return self._status_filter_schema()
 
     def get_chart_data(self, user, filters):
-        qs = ProductionOrder.objects.all()
+        qs = self.filter_queryset(user, ProductionOrder.objects.all())
         statuses = filters.get("status")
         if statuses:
             qs = qs.filter(status__in=statuses)
@@ -113,7 +116,7 @@ class ProductionOrdersPerItemLineChart(_StatusFilterMixin, LineChartBlock):
         return self._status_filter_schema()
 
     def get_chart_data(self, user, filters):
-        qs = ProductionOrder.objects.all()
+        qs = self.filter_queryset(user, ProductionOrder.objects.all())
         statuses = filters.get("status")
         if statuses:
             qs = qs.filter(status__in=statuses)

--- a/apps/production/test_charts.py
+++ b/apps/production/test_charts.py
@@ -9,6 +9,7 @@ from apps.production.charts import (
     ProductionOrdersPerItemLineChart,
 )
 from apps.common.models import ProductionOrder, Item
+from apps.accounts.models.custom_user import CustomUser
 
 
 class ProductionChartsTests(TestCase):
@@ -16,6 +17,7 @@ class ProductionChartsTests(TestCase):
         self.status_chart = ProductionOrdersByStatusChart()
         self.bar_chart = ProductionOrdersPerItemBarChart()
         self.line_chart = ProductionOrdersPerItemLineChart()
+        self.user = CustomUser.objects.create(username="tester", is_superuser=True)
 
         item1 = Item.objects.create(code="ITM1")
         item2 = Item.objects.create(code="ITM2")
@@ -37,17 +39,17 @@ class ProductionChartsTests(TestCase):
         self.assertEqual(cfg.get("type"), "multiselect")
 
     def test_donut_chart_counts_by_status(self):
-        data = self.status_chart.get_chart_data(None, {})
+        data = self.status_chart.get_chart_data(self.user, {})
         self.assertEqual(data["labels"], ["closed", "open"])
         self.assertEqual(data["values"], [1, 2])
 
     def test_bar_chart_filters_by_status(self):
-        data = self.bar_chart.get_chart_data(None, {"status": ["open"]})
+        data = self.bar_chart.get_chart_data(self.user, {"status": ["open"]})
         self.assertEqual(data["x"], ["ITM1"])
         self.assertEqual(data["y"], [2])
 
     def test_line_chart_returns_all_items(self):
-        data = self.line_chart.get_chart_data(None, {})
+        data = self.line_chart.get_chart_data(self.user, {})
         self.assertEqual(data["x"], ["ITM1", "ITM2"])
         self.assertEqual(data["y"], [2, 1])
 


### PR DESCRIPTION
## Summary
- Respect field and row permissions in chart blocks
- Apply viewable-row filtering and field checks in production charts
- Cover chart permission logic with dedicated tests

## Testing
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mag360.test_settings')
django.setup()
from django.test.utils import get_runner
from django.conf import settings
TestRunner = get_runner(settings)
test_runner = TestRunner(verbosity=1)
failures = test_runner.run_tests(['apps.blocks.tests.ChartBlockPermissionTests', 'apps.production.test_charts.ProductionChartsTests'])
exit(bool(failures))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af553a22a88330875d8693e720fdb0