### PR TITLE
Prevent filter name JS error in filter forms

### DIFF
--- a/apps/blocks/templates/blocks/chart/filter_config_view.html
+++ b/apps/blocks/templates/blocks/chart/filter_config_view.html
@@ -194,7 +194,7 @@
   });
 
   document.getElementById('filter-form').addEventListener('submit', function (e) {
-    const name = nameInput.value.trim();
+    const name = nameInput && nameInput.value ? nameInput.value.trim() : '';
     if (!name) {
       e.preventDefault();
       alert('Please enter a name for this filter.');

--- a/apps/blocks/templates/blocks/table/filter_config_view.html
+++ b/apps/blocks/templates/blocks/table/filter_config_view.html
@@ -195,7 +195,7 @@
   });
 
   document.getElementById('filter-form').addEventListener('submit', function (e) {
-    const name = nameInput.value.trim();
+    const name = nameInput && nameInput.value ? nameInput.value.trim() : '';
     if (!name) {
       e.preventDefault();
       alert('Please enter a name for this filter.');

--- a/apps/layout/templates/layout/layout_filter_config.html
+++ b/apps/layout/templates/layout/layout_filter_config.html
@@ -190,7 +190,7 @@
   });
 
   document.getElementById('filter-form').addEventListener('submit', function (e) {
-    const name = nameInput.value.trim();
+    const name = nameInput && nameInput.value ? nameInput.value.trim() : '';
     if (!name) {
       e.preventDefault();
       alert('Please enter a name for this filter.');


### PR DESCRIPTION
## Summary
- Guard against missing filter names to avoid `trim` on undefined in filter configuration forms.
- Use simple conditional check instead of optional chaining for broader browser support.

## Testing
- `pytest apps/production/test_charts.py::ProductionChartsTests::test_line_chart_returns_all_items -q` *(fails: no such table: accounts_customuser)*

------
https://chatgpt.com/codex/tasks/task_e_68af5ed740bc83309209b50aa1f4dcc1